### PR TITLE
enable logging middleware by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,10 @@ authors = ["Yoshua Wuyts <yoshuawuyts@gmail.com>"]
 readme = "README.md"
 edition = "2018"
 
+[features]
+default = ["middleware-logger"]
+middleware-logger = []
+
 [dependencies]
 hyper = { version = "0.12.32", default-features = false }
 http = "0.1.17"
@@ -22,6 +26,8 @@ runtime = "0.3.0-alpha.6"
 native-tls = "0.2.2"
 runtime-tokio = "0.3.0-alpha.5"
 runtime-raw = "0.3.0-alpha.4"
+log = { version = "0.4.7", features = ["kv_unstable"] }
 
 [dev-dependencies]
 serde = { version = "1.0.97", features = ["derive"] }
+femme = "1.1.0"

--- a/examples/google.rs
+++ b/examples/google.rs
@@ -3,10 +3,11 @@ type Exception = Box<dyn std::error::Error + Send + Sync + 'static>;
 
 #[runtime::main]
 async fn main() -> Result<(), Exception> {
-    let string = surf::get("https://google.com")
-        .middleware(surf::middleware::logger::new())
-        .recv_string()
-        .await?;
-    dbg!(string);
+    femme::start(log::LevelFilter::Info)?;
+
+    let uri = "https://google.com";
+    let string = surf::get(uri).recv_string().await?;
+    println!("{}", string);
+
     Ok(())
 }

--- a/examples/persistent.rs
+++ b/examples/persistent.rs
@@ -3,18 +3,10 @@ type Exception = Box<dyn std::error::Error + Send + Sync + 'static>;
 
 #[runtime::main]
 async fn main() -> Result<(), Exception> {
+    femme::start(log::LevelFilter::Info)?;
     let client = surf::Client::new();
-
-    let req1 = client
-        .get("https://google.com")
-        .middleware(surf::middleware::logger::new())
-        .recv_string();
-
-    let req2 = client
-        .get("https://google.com")
-        .middleware(surf::middleware::logger::new())
-        .recv_string();
-
+    let req1 = client.get("https://google.com").recv_string();
+    let req2 = client.get("https://google.com").recv_string();
     futures::future::try_join(req1, req2).await?;
     Ok(())
 }

--- a/examples/post.rs
+++ b/examples/post.rs
@@ -2,6 +2,8 @@
 
 #[runtime::main]
 async fn main() -> Result<(), surf::Exception> {
+    femme::start(log::LevelFilter::Info)?;
+
     #[derive(serde::Serialize)]
     struct Cat {
         name: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,10 @@
 //! assert!(ip.len() > 10);
 //! # Ok(()) }
 //! ```
+//!
+//! # Features
+//! By default all features are enabled.
+//! - `middleware-logger` enables logging requests and responses using a middleware.
 
 #![forbid(unsafe_code, future_incompatible, rust_2018_idioms)]
 #![deny(missing_debug_implementations, nonstandard_style)]

--- a/src/middleware/logger.rs
+++ b/src/middleware/logger.rs
@@ -17,6 +17,10 @@ use crate::middleware::{Middleware, Next, Request, Response};
 
 use futures::future::BoxFuture;
 use std::time;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::fmt::Arguments;
+
+static COUNTER: AtomicUsize = AtomicUsize::new(0);
 
 /// Log each request's duration
 #[derive(Debug)]
@@ -30,10 +34,34 @@ impl<C: HttpClient> Middleware<C> for Logger {
         next: Next<'a, C>,
     ) -> BoxFuture<'a, Result<Response, crate::Exception>> {
         Box::pin(async move {
-            println!("sending request to {}", req.uri());
-            let now = time::Instant::now();
+            let start_time = time::Instant::now();
+            let uri = format!("{}", req.uri());
+            let method = format!("{}", req.method());
+            let id = COUNTER.fetch_add(1, Ordering::SeqCst);
+            print(log::Level::Info, format_args!("sending request"), RequestPairs {
+                id,
+                uri: &uri,
+                method: &method,
+            });
+
             let res = next.run(req, client).await?;
-            println!("request completed ({:?})", now.elapsed());
+
+            let status = res.status();
+            let elapsed = start_time.elapsed();
+            let level = if status.is_server_error() {
+                log::Level::Error
+            } else if status.is_client_error() {
+                log::Level::Warn
+            } else {
+                log::Level::Info
+            };
+
+            print(level, format_args!("request completed"), ResponsePairs {
+                id,
+                elapsed: &format!("{:?}", elapsed),
+                status: status.as_u16(),
+            });
+
             Ok(res)
         })
     }
@@ -42,4 +70,53 @@ impl<C: HttpClient> Middleware<C> for Logger {
 /// Create a new instance.
 pub fn new() -> Logger {
     Logger {}
+}
+
+struct RequestPairs<'a> {
+    id: usize,
+    method: &'a str,
+    uri: &'a str,
+}
+impl<'a> log::kv::Source for RequestPairs<'a> {
+    fn visit<'kvs>(
+        &'kvs self,
+        visitor: &mut dyn log::kv::Visitor<'kvs>
+    ) -> Result<(), log::kv::Error> {
+        visitor.visit_pair("req.id".into(), self.id.into())?;
+        visitor.visit_pair("req.method".into(), self.method.into())?;
+        visitor.visit_pair("req.uri".into(), self.uri.into())?;
+        Ok(())
+    }
+}
+
+struct ResponsePairs<'a> {
+    id: usize,
+    status: u16,
+    elapsed: &'a str,
+}
+
+impl<'a> log::kv::Source for ResponsePairs<'a> {
+    fn visit<'kvs>(
+        &'kvs self,
+        visitor: &mut dyn log::kv::Visitor<'kvs>
+    ) -> Result<(), log::kv::Error> {
+        visitor.visit_pair("req.id".into(), self.id.into())?;
+        visitor.visit_pair("req.status".into(), self.status.into())?;
+        visitor.visit_pair("elapsed".into(), self.elapsed.into())?;
+        Ok(())
+    }
+}
+
+fn print(level: log::Level, msg: Arguments<'_>, key_values: impl log::kv::Source) {
+    if level <= log::STATIC_MAX_LEVEL && level <= log::max_level() {
+        log::logger().log(&log::Record::builder()
+            .args(msg)
+            .key_values(&key_values)
+            .level(level)
+            .target(module_path!())
+            .module_path(Some(module_path!()))
+            .file(Some(file!()))
+            .line(Some(line!()))
+            .build());
+    }
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -56,7 +56,7 @@ impl Request<HyperClient> {
 impl<C: HttpClient> Request<C> {
     /// Create a new instance with an `HttpClient` instance.
     pub fn with_client(method: http::Method, uri: http::Uri, client: C) -> Self {
-        Self {
+        let client = Self {
             fut: None,
             client: Some(client),
             req: Some(RequestState {
@@ -66,7 +66,12 @@ impl<C: HttpClient> Request<C> {
                 method,
                 uri,
             }),
-        }
+        };
+
+        #[cfg(feature="middleware-logger")]
+        let client = client.middleware(crate::middleware::logger::new());
+
+        client
     }
 
     /// Push middleware onto the middleware stack.


### PR DESCRIPTION
- implements logging middleware using key-value logs
- adds a feature to be able to toggle it off if not desired
- added `femme` to the examples
- added a section to readme to outline which features can be toggled

## Screenshot
![2019-07-26-225301_1920x1080](https://user-images.githubusercontent.com/2467194/61980847-23ddcf00-aff8-11e9-8924-5b6bee8acbc8.png)
