### PR TITLE
Follow redirects

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,24 +12,31 @@ readme = "README.md"
 edition = "2018"
 
 [features]
-default = ["middleware-logger"]
+default = ["chttp", "middleware-logger"]
+hyper-client = ["hyper", "runtime", "runtime-raw", "runtime-tokio" ]
+chttp-client = ["chttp"]
 middleware-logger = []
 
 [dependencies]
-hyper = { version = "0.12.32", default-features = false }
 http = "0.1.17"
 futures-preview = { version = "0.3.0-alpha.17", features = ["compat", "io-compat"] }
 serde = "1.0.97"
 serde_json = "1.0.40"
-hyper-tls = "0.3.2"
-runtime = "0.3.0-alpha.6"
-native-tls = "0.2.2"
-runtime-tokio = "0.3.0-alpha.5"
-runtime-raw = "0.3.0-alpha.4"
 log = { version = "0.4.7", features = ["kv_unstable"] }
 url = "2.0.0"
 mime_guess = "2.0.0-alpha.6"
 mime = "0.3.13"
+
+# Chttp
+chttp = { version = "0.5.3", optional = true }
+
+# Hyper deps
+hyper = { version = "0.12.32", optional = true, default-features = false }
+hyper-tls = { version = "0.3.2", optional = true }
+runtime = { version = "0.3.0-alpha.6", optional = true }
+native-tls = { version = "0.2.2", optional = true }
+runtime-raw = { version = "0.3.0-alpha.4", optional = true }
+runtime-tokio = { version = "0.3.0-alpha.5", optional = true }
 
 [dev-dependencies]
 serde = { version = "1.0.97", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,12 @@ readme = "README.md"
 edition = "2018"
 
 [features]
-default = ["chttp-client", "middleware-logger"]
+default = ["chttp-client", "middleware-default"]
 hyper-client = ["hyper", "runtime", "runtime-raw", "runtime-tokio" ]
 chttp-client = ["chttp"]
+middleware-default = ["middleware-logger", "middleware-redirect"]
 middleware-logger = []
+middleware-redirect = []
 
 [dependencies]
 http = "0.1.17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 edition = "2018"
 
 [features]
-default = ["chttp", "middleware-logger"]
+default = ["chttp-client", "middleware-logger"]
 hyper-client = ["hyper", "runtime", "runtime-raw", "runtime-tokio" ]
 chttp-client = ["chttp"]
 middleware-logger = []
@@ -40,4 +40,5 @@ runtime-tokio = { version = "0.3.0-alpha.5", optional = true }
 
 [dev-dependencies]
 serde = { version = "1.0.97", features = ["derive"] }
+runtime = "0.3.0-alpha.6"
 femme = "1.1.0"

--- a/examples/google.rs
+++ b/examples/google.rs
@@ -3,9 +3,9 @@ type Exception = Box<dyn std::error::Error + Send + Sync + 'static>;
 
 #[runtime::main]
 async fn main() -> Result<(), Exception> {
-    femme::start(log::LevelFilter::Info)?;
+    femme::start(log::LevelFilter::Debug)?;
 
-    let uri = "https://google.com";
+    let uri = "https://httpbin.org/status/301";
     let string = surf::get(uri).recv_string().await?;
     println!("{}", string);
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,6 +1,8 @@
-use crate::http_client::hyper::HyperClient;
 use crate::http_client::HttpClient;
 use crate::Request;
+
+#[cfg(feature = "chttp-client")]
+use crate::http_client::chttp::ChttpClient;
 
 /// A persistent HTTP client.
 #[derive(Debug)]
@@ -8,10 +10,11 @@ pub struct Client<C: HttpClient> {
     client: C,
 }
 
-impl Client<HyperClient> {
+#[cfg(feature = "chttp-client")]
+impl Client<ChttpClient> {
     /// Create a new instance.
     pub fn new() -> Self {
-        Self::with_client(HyperClient::new())
+        Self::with_client(ChttpClient::new())
     }
 }
 

--- a/src/http_client/chttp.rs
+++ b/src/http_client/chttp.rs
@@ -1,0 +1,37 @@
+use futures::future::BoxFuture;
+use chttp;
+
+use super::{Body, HttpClient, Request, Response};
+
+/// Curl HTTP Client.
+///
+/// ## Performance
+/// Libcurl is not thread safe, which means unfortunatley we cannot reuse connections or multiplex.
+#[derive(Debug)]
+pub struct ChttpClient {
+    _priv: ()
+}
+
+impl ChttpClient {
+    /// Create a new instance.
+    pub fn new() -> Self {
+        Self { _priv: () }
+    }
+}
+
+impl Clone for ChttpClient {
+    fn clone(&self) -> Self {
+        Self::new()
+    }
+}
+
+impl HttpClient for ChttpClient {
+    type Error = chttp::Error;
+
+    fn send(&self, req: Request) -> BoxFuture<'static, Result<Response, Self::Error>> {
+        Box::pin(async move {
+            unimplemented!();
+        })
+    }
+}
+

--- a/src/http_client/chttp.rs
+++ b/src/http_client/chttp.rs
@@ -17,7 +17,7 @@ impl ChttpClient {
     /// Create a new instance.
     pub fn new() -> Self {
         Self {
-            client: Arc::new(chttp::HttpClient::new())
+            client: Arc::new(chttp::HttpClient::new()),
         }
     }
 }
@@ -25,7 +25,7 @@ impl ChttpClient {
 impl Clone for ChttpClient {
     fn clone(&self) -> Self {
         Self {
-            client: self.client.clone()
+            client: self.client.clone(),
         }
     }
 }
@@ -49,4 +49,3 @@ impl HttpClient for ChttpClient {
         })
     }
 }
-

--- a/src/http_client/mod.rs
+++ b/src/http_client/mod.rs
@@ -8,7 +8,11 @@ use std::io;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
+#[cfg(feature = "hyper-client")]
 pub(crate) mod hyper;
+
+#[cfg(feature = "chttp-client")]
+pub(crate) mod chttp;
 
 /// An HTTP Request type with a streaming body.
 pub type Request = http::Request<Body>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,9 +69,9 @@ mod response;
 
 pub mod middleware;
 
-pub use url;
 pub use http;
 pub use mime;
+pub use url;
 
 pub use client::Client;
 pub use request::Request;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,6 @@
 
 mod client;
 mod http_client;
-mod one_off;
 mod request;
 mod response;
 
@@ -75,9 +74,13 @@ pub use http;
 pub use mime;
 
 pub use client::Client;
-pub use one_off::{connect, delete, get, head, options, patch, post, put, trace};
 pub use request::Request;
 pub use response::Response;
+
+#[cfg(feature = "chttp-client")]
+mod one_off;
+#[cfg(feature = "chttp-client")]
+pub use one_off::{connect, delete, get, head, options, patch, post, put, trace};
 
 /// A generic error type.
 pub type Exception = Box<dyn std::error::Error + Send + Sync + 'static>;

--- a/src/middleware/logger.rs
+++ b/src/middleware/logger.rs
@@ -16,9 +16,9 @@ use crate::http_client::HttpClient;
 use crate::middleware::{Middleware, Next, Request, Response};
 
 use futures::future::BoxFuture;
-use std::time;
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::fmt::Arguments;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time;
 
 static COUNTER: AtomicUsize = AtomicUsize::new(0);
 
@@ -38,11 +38,15 @@ impl<C: HttpClient> Middleware<C> for Logger {
             let uri = format!("{}", req.uri());
             let method = format!("{}", req.method());
             let id = COUNTER.fetch_add(1, Ordering::SeqCst);
-            print(log::Level::Info, format_args!("sending request"), RequestPairs {
-                id,
-                uri: &uri,
-                method: &method,
-            });
+            print(
+                log::Level::Info,
+                format_args!("sending request"),
+                RequestPairs {
+                    id,
+                    uri: &uri,
+                    method: &method,
+                },
+            );
 
             let res = next.run(req, client).await?;
 
@@ -56,11 +60,15 @@ impl<C: HttpClient> Middleware<C> for Logger {
                 log::Level::Info
             };
 
-            print(level, format_args!("request completed"), ResponsePairs {
-                id,
-                elapsed: &format!("{:?}", elapsed),
-                status: status.as_u16(),
-            });
+            print(
+                level,
+                format_args!("request completed"),
+                ResponsePairs {
+                    id,
+                    elapsed: &format!("{:?}", elapsed),
+                    status: status.as_u16(),
+                },
+            );
 
             Ok(res)
         })
@@ -80,7 +88,7 @@ struct RequestPairs<'a> {
 impl<'a> log::kv::Source for RequestPairs<'a> {
     fn visit<'kvs>(
         &'kvs self,
-        visitor: &mut dyn log::kv::Visitor<'kvs>
+        visitor: &mut dyn log::kv::Visitor<'kvs>,
     ) -> Result<(), log::kv::Error> {
         visitor.visit_pair("req.id".into(), self.id.into())?;
         visitor.visit_pair("req.method".into(), self.method.into())?;
@@ -98,7 +106,7 @@ struct ResponsePairs<'a> {
 impl<'a> log::kv::Source for ResponsePairs<'a> {
     fn visit<'kvs>(
         &'kvs self,
-        visitor: &mut dyn log::kv::Visitor<'kvs>
+        visitor: &mut dyn log::kv::Visitor<'kvs>,
     ) -> Result<(), log::kv::Error> {
         visitor.visit_pair("req.id".into(), self.id.into())?;
         visitor.visit_pair("req.status".into(), self.status.into())?;
@@ -109,14 +117,16 @@ impl<'a> log::kv::Source for ResponsePairs<'a> {
 
 fn print(level: log::Level, msg: Arguments<'_>, key_values: impl log::kv::Source) {
     if level <= log::STATIC_MAX_LEVEL && level <= log::max_level() {
-        log::logger().log(&log::Record::builder()
-            .args(msg)
-            .key_values(&key_values)
-            .level(level)
-            .target(module_path!())
-            .module_path(Some(module_path!()))
-            .file(Some(file!()))
-            .line(Some(line!()))
-            .build());
+        log::logger().log(
+            &log::Record::builder()
+                .args(msg)
+                .key_values(&key_values)
+                .level(level)
+                .target(module_path!())
+                .module_path(Some(module_path!()))
+                .file(Some(file!()))
+                .line(Some(line!()))
+                .build(),
+        );
     }
 }

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -52,6 +52,7 @@
 pub use crate::http_client::{Body, HttpClient, Request, Response};
 
 pub mod logger;
+pub mod redirect;
 
 use crate::Exception;
 use futures::future::BoxFuture;

--- a/src/middleware/redirect.rs
+++ b/src/middleware/redirect.rs
@@ -1,0 +1,65 @@
+//! Follow redirects.
+//!
+//! # Examples
+//! ```
+//! # #![feature(async_await)]
+//! # #[runtime::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+//! let mut res = surf::get("http://google.com")
+//!     .middleware(surf::middleware::follow::new())
+//!     .await?;
+//! dbg!(res.body_string().await?);
+//! # Ok(()) }
+//! ```
+
+use futures::future::BoxFuture;
+
+use std::io;
+
+use crate::http_client::HttpClient;
+use crate::middleware::{Middleware, Next, Request, Response};
+
+/// Max number of redirects followed.
+pub static MAX_REDIRECTS: u8 = 10;
+
+/// Log each request's duration
+#[derive(Debug)]
+pub struct Redirect;
+
+impl<C: HttpClient> Middleware<C> for Redirect {
+    fn handle<'a>(
+        &'a self,
+        req: Request,
+        client: C,
+        next: Next<'a, C>,
+    ) -> BoxFuture<'a, Result<Response, crate::Exception>> {
+        async fn handle<'a, C: HttpClient>(
+            _this: &'a Redirect,
+            req: Request,
+            client: C,
+            next: Next<'a, C>,
+            redirects_followed: u8,
+        ) -> Result<Response, crate::Exception> {
+            let method = req.method().clone();
+
+            let res = next.run(req, client).await?;
+
+            if res.status().is_redirection() {
+                let location = res.headers().get("Location");
+                log::debug!("redirect {:?}", location);
+                if redirects_followed >= MAX_REDIRECTS {
+                    let err = io::Error::new(io::ErrorKind::Other, "Max redirects reached").into();
+                    return Err(err);
+                }
+            }
+            Ok(res)
+        }
+
+        Box::pin(handle(self, req, client, next, 0))
+    }
+}
+
+/// Create a new instance.
+pub fn new() -> Redirect {
+    Redirect {}
+}

--- a/src/one_off.rs
+++ b/src/one_off.rs
@@ -1,4 +1,4 @@
-use super::http_client::hyper::HyperClient;
+use super::http_client::chttp::ChttpClient;
 use super::Request;
 
 /// Perform a one-off `GET` request.
@@ -11,7 +11,7 @@ use super::Request;
 /// [Read more on MDN]
 ///
 /// [Read more on MDN]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/GET
-pub fn get(uri: impl AsRef<str>) -> Request<HyperClient> {
+pub fn get(uri: impl AsRef<str>) -> Request<ChttpClient> {
     let uri = uri.as_ref().to_owned().parse().unwrap();
     Request::new(http::Method::GET, uri)
 }
@@ -35,7 +35,7 @@ pub fn get(uri: impl AsRef<str>) -> Request<HyperClient> {
 /// [Read more on MDN]
 ///
 /// [Read more on MDN]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/HEAD
-pub fn head(uri: impl AsRef<str>) -> Request<HyperClient> {
+pub fn head(uri: impl AsRef<str>) -> Request<ChttpClient> {
     let uri = uri.as_ref().to_owned().parse().unwrap();
     Request::new(http::Method::HEAD, uri)
 }
@@ -76,7 +76,7 @@ pub fn head(uri: impl AsRef<str>) -> Request<HyperClient> {
 /// [Read more on MDN]
 ///
 /// [Read more on MDN]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/POST
-pub fn post(uri: impl AsRef<str>) -> Request<HyperClient> {
+pub fn post(uri: impl AsRef<str>) -> Request<ChttpClient> {
     let uri = uri.as_ref().to_owned().parse().unwrap();
     Request::new(http::Method::POST, uri)
 }
@@ -95,7 +95,7 @@ pub fn post(uri: impl AsRef<str>) -> Request<HyperClient> {
 /// [Read more on MDN]
 ///
 /// [Read more on MDN]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/PUT
-pub fn put(uri: impl AsRef<str>) -> Request<HyperClient> {
+pub fn put(uri: impl AsRef<str>) -> Request<ChttpClient> {
     let uri = uri.as_ref().to_owned().parse().unwrap();
     Request::new(http::Method::PUT, uri)
 }
@@ -109,7 +109,7 @@ pub fn put(uri: impl AsRef<str>) -> Request<HyperClient> {
 /// [Read more on MDN]
 ///
 /// [Read more on MDN]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/DELETE
-pub fn delete(uri: impl AsRef<str>) -> Request<HyperClient> {
+pub fn delete(uri: impl AsRef<str>) -> Request<ChttpClient> {
     let uri = uri.as_ref().to_owned().parse().unwrap();
     Request::new(http::Method::DELETE, uri)
 }
@@ -132,7 +132,7 @@ pub fn delete(uri: impl AsRef<str>) -> Request<HyperClient> {
 /// [Read more on MDN]
 ///
 /// [Read more on MDN]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/CONNECT
-pub fn connect(uri: impl AsRef<str>) -> Request<HyperClient> {
+pub fn connect(uri: impl AsRef<str>) -> Request<ChttpClient> {
     let uri = uri.as_ref().to_owned().parse().unwrap();
     Request::new(http::Method::CONNECT, uri)
 }
@@ -148,7 +148,7 @@ pub fn connect(uri: impl AsRef<str>) -> Request<HyperClient> {
 /// [Read more on MDN]
 ///
 /// [Read more on MDN]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/OPTIONS
-pub fn options(uri: impl AsRef<str>) -> Request<HyperClient> {
+pub fn options(uri: impl AsRef<str>) -> Request<ChttpClient> {
     let uri = uri.as_ref().to_owned().parse().unwrap();
     Request::new(http::Method::OPTIONS, uri)
 }
@@ -168,7 +168,7 @@ pub fn options(uri: impl AsRef<str>) -> Request<HyperClient> {
 /// [Read more on MDN]
 ///
 /// [Read more on MDN]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/TRACE
-pub fn trace(uri: impl AsRef<str>) -> Request<HyperClient> {
+pub fn trace(uri: impl AsRef<str>) -> Request<ChttpClient> {
     let uri = uri.as_ref().to_owned().parse().unwrap();
     Request::new(http::Method::TRACE, uri)
 }
@@ -194,7 +194,7 @@ pub fn trace(uri: impl AsRef<str>) -> Request<HyperClient> {
 /// [Read more on MDN]
 ///
 /// [Read more on MDN]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/PATCH
-pub fn patch(uri: impl AsRef<str>) -> Request<HyperClient> {
+pub fn patch(uri: impl AsRef<str>) -> Request<ChttpClient> {
     let uri = uri.as_ref().to_owned().parse().unwrap();
     Request::new(http::Method::PATCH, uri)
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -5,13 +5,11 @@ use http::Method;
 use url::Url;
 use mime::Mime;
 
-use super::http_client::hyper::HyperClient;
 use super::http_client::{self, Body, HttpClient};
 use super::middleware::{Middleware, Next};
 use super::Exception;
 use super::Response;
 
-use std::convert::TryFrom;
 use std::fmt;
 use std::fmt::Debug;
 use std::future::Future;
@@ -21,6 +19,11 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::path::Path;
 use std::fs;
+
+#[cfg(feature = "chttp-client")]
+use super::http_client::chttp::ChttpClient;
+#[cfg(feature = "chttp-client")]
+use std::convert::TryFrom;
 
 /// Create an HTTP request.
 pub struct Request<C: HttpClient + Debug + Unpin + Send + Sync> {
@@ -36,10 +39,11 @@ pub struct Request<C: HttpClient + Debug + Unpin + Send + Sync> {
     url: Url,
 }
 
-impl Request<HyperClient> {
+#[cfg(feature = "chttp-client")]
+impl Request<ChttpClient> {
     /// Create a new instance.
     pub fn new(method: http::Method, url: Url) -> Self {
-        Self::with_client(method, url, HyperClient::new())
+        Self::with_client(method, url, ChttpClient::new())
     }
 }
 
@@ -221,8 +225,9 @@ impl<C: HttpClient> Future for Request<C> {
     }
 }
 
+#[cfg(feature = "chttp-client")]
 impl<R: AsyncRead + Unpin + Send + 'static> TryFrom<http::Request<Box<R>>>
-    for Request<HyperClient>
+    for Request<ChttpClient>
 {
     type Error = io::Error;
 


### PR DESCRIPTION
Builds on #17. Attempt to implement #18. But ooph, this is not easy.

## parse url
A lot of `Location` headers are relative or even just a part of a URL. We should have something like node's `url.resolve()` to create complete URLs. Possibly as an extension to the url crate.

```js
const resolvedUrl = url.resolve(req.url, res.headers.get('location'))
let redirectURL = url.parse(resolvedUrl)

if (isURL.test(res.headers.get('location'))) {
redirectURL = url.parse(res.headers.get('location'))
```

## Detect streams
So if we're going to retry requests, we can't just be streaming from a moving target. Instead we need to make sure we own the streaming resource.

I think we may need to include more information in the middleware, which means changing the `client` param to a `Context` struct to contain more information. We can the follow make-fetch-happen's lead and add a `is-stream` flag to it, and not retry if it's not from a source that wont' mutate.

## Auth retries
I kind of don't want to touch this one for now; seems tricky hah.

## References
- https://github.com/zkat/make-fetch-happen/blob/latest/index.js#L329
- https://github.com/servo/rust-url/issues/2