### PR TITLE
Implement convenience methods for hyper-client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 [features]
 default = ["native-client", "middleware-logger"]
 native-client = ["curl-client", "wasm-client"]
-hyper-client = ["hyper", "runtime", "runtime-raw", "runtime-tokio" ]
+hyper-client = ["hyper", "runtime", "runtime-raw", "runtime-tokio", "hyper-tls", "native-tls" ]
 curl-client = ["chttp"]
 wasm-client = ["js-sys", "web-sys", "wasm-bindgen", "wasm-bindgen-futures"]
 middleware-logger = []

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,6 +1,8 @@
 use crate::http_client::HttpClient;
 use crate::Request;
 
+#[cfg(feature = "hyper-client")]
+use super::http_client::hyper::HyperClient;
 #[cfg(feature = "native-client")]
 use super::http_client::native::NativeClient;
 
@@ -38,6 +40,24 @@ impl Client<NativeClient> {
     /// ```
     pub fn new() -> Self {
         Self::with_client(NativeClient::new())
+    }
+}
+
+#[cfg(feature = "hyper-client")]
+impl Client<HyperClient> {
+    /// Create a new instance.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # #![feature(async_await)]
+    /// # #[runtime::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+    /// let client = surf::Client::new();
+    /// # Ok(()) }
+    /// ```
+    pub fn new() -> Self {
+        Self::with_client(HyperClient::new())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,9 +95,9 @@ pub use client::Client;
 pub use request::Request;
 pub use response::Response;
 
-#[cfg(feature = "native-client")]
+#[cfg(any(feature = "native-client", feature = "hyper-client"))]
 mod one_off;
-#[cfg(feature = "native-client")]
+#[cfg(any(feature = "native-client", feature = "hyper-client"))]
 pub use one_off::{connect, delete, get, head, options, patch, post, put, trace};
 
 /// A generic error type.

--- a/src/one_off.rs
+++ b/src/one_off.rs
@@ -1,6 +1,9 @@
 #[cfg(feature = "native-client")]
 use super::http_client::native::NativeClient;
 
+#[cfg(feature = "hyper-client")]
+use super::http_client::hyper::HyperClient as NativeClient;
+
 use super::Request;
 
 /// Perform a one-off `GET` request.

--- a/src/request.rs
+++ b/src/request.rs
@@ -458,7 +458,7 @@ impl<C: HttpClient> Request<C> {
     /// # Ok(()) }
     /// ```
     pub fn body_file(mut self, path: impl AsRef<Path>) -> io::Result<Self> {
-        let mime = mime_guess::guess_mime_type(&path);
+        let mime = mime_guess::from_path(&path).first_or_octet_stream();
         let bytes = fs::read(path)?;
         *self.req.as_mut().unwrap().body_mut() = bytes.into();
         Ok(self.set_mime(mime))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Implement convenience methods for use with hyper-client, enable TLS by default for hyper-client and fix the build by removing a deprecated method.


## Motivation and Context

I'm running on macOS with the curl library not immediately available.
Hyper on the other hand works just fine.
However, most convenience things weren't implemented.

This PR changes multiple things, I'm happy to split them up if wanted.

## How Has This Been Tested?

`cargo test --no-default-features --features hyper-client`


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](https://github.com/rust-net-web/tide/blob/master/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
