### PR TITLE
Add support for hyper-rustls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,9 @@ isahc = { version = "0.7", optional = true, default-features = false, features =
 # hyper-client
 hyper = { version = "0.12.32", optional = true, default-features = false }
 hyper-tls = { version = "0.3.2", optional = true }
+hyper-rustls = { version = "0.17.0", optional = true }
 native-tls = { version = "0.2.2", optional = true }
+rustls = { version = "0.16.0", optional = true }
 runtime = { version = "0.3.0-alpha.6", optional = true }
 runtime-raw = { version = "0.3.0-alpha.4", optional = true }
 runtime-tokio = { version = "0.3.0-alpha.5", optional = true }


### PR DESCRIPTION
## Description

Allow the hyper client to be configured to use `hyper-rustls` for TLS abilities, eliminating the dependency on the OS TLS library/OpenSSL.

## Motivation and Context

Fixes #40 

This is a quick pass at using `hyper-rustls` instead of `native-tls`. `rustls` makes cross-compiling easier and eliminates a dependency on a C library (OpenSSL) on open source OSes.

## How Has This Been Tested?

These changes build with `cargo build --no-default-features --features hyper-client,hyper-rustls,rustls`. However, `cargo test --no-default-features --features hyper-client,hyper-rustls,rustls` fails. It appears that running the tests is broken on master with `native-tls` too, as `cargo test --no-default-features --features hyper-client,hyper-tls,native-tls` also fails.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/rust-net-web/tide/blob/master/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
