### PR TITLE
Makes http_client contents public.

### DIFF
--- a/src/http_client/isahc.rs
+++ b/src/http_client/isahc.rs
@@ -10,15 +10,9 @@ pub struct IsahcClient {
     client: Arc<isahc::HttpClient>,
 }
 
-impl Default for IsahcClient {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl IsahcClient {
     /// Create a new instance.
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             client: Arc::new(isahc::HttpClient::new().unwrap()),
         }

--- a/src/http_client/isahc.rs
+++ b/src/http_client/isahc.rs
@@ -1,3 +1,5 @@
+//! HTTP Client adapter for Isahc.
+
 use super::{Body, HttpClient, Request, Response};
 
 use futures::future::BoxFuture;

--- a/src/http_client/mod.rs
+++ b/src/http_client/mod.rs
@@ -9,16 +9,16 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 
 #[cfg(all(feature = "hyper-client", not(target_arch = "wasm32")))]
-pub(crate) mod hyper;
+pub mod hyper;
 
 #[cfg(all(feature = "curl-client", not(target_arch = "wasm32")))]
-pub(crate) mod isahc;
+pub mod isahc;
 
 #[cfg(all(feature = "wasm-client", target_arch = "wasm32"))]
-pub(crate) mod wasm;
+pub mod wasm;
 
 #[cfg(feature = "native-client")]
-pub(crate) mod native;
+pub mod native;
 
 /// An HTTP Request type with a streaming body.
 pub type Request = http::Request<Body>;

--- a/src/http_client/native.rs
+++ b/src/http_client/native.rs
@@ -1,5 +1,5 @@
 #[cfg(all(feature = "curl-client", not(target_arch = "wasm32")))]
-pub(crate) use super::isahc::IsahcClient as NativeClient;
+pub use super::isahc::IsahcClient as NativeClient;
 
 #[cfg(all(feature = "wasm-client", target_arch = "wasm32"))]
-pub(crate) use super::wasm::WasmClient as NativeClient;
+pub use super::wasm::WasmClient as NativeClient;

--- a/src/http_client/native.rs
+++ b/src/http_client/native.rs
@@ -1,3 +1,5 @@
+//! HTTP Client adapter for architecture-native libraries.
+
 #[cfg(all(feature = "curl-client", not(target_arch = "wasm32")))]
 pub use super::isahc::IsahcClient as NativeClient;
 

--- a/src/http_client/wasm.rs
+++ b/src/http_client/wasm.rs
@@ -1,3 +1,5 @@
+//! HTTP Client adapter for WASM.
+
 use super::{Body, HttpClient, Request, Response};
 
 use futures::future::BoxFuture;

--- a/src/http_client/wasm.rs
+++ b/src/http_client/wasm.rs
@@ -15,7 +15,7 @@ pub struct WasmClient {
 
 impl WasmClient {
     /// Create a new instance.
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self { _priv: () }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,11 +75,11 @@
 #![cfg_attr(test, deny(warnings))]
 
 mod client;
-mod http_client;
 mod request;
 mod response;
 
 pub mod headers;
+pub mod http_client;
 pub mod middleware;
 
 pub use http;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
However, to retain stability guarantees, their implementations are kept private to the crate.

## Motivation and Context
Fixes #54.
<!--- Why is this change required? What problem does it solve? -->
`Client` and `Request` are hard to pass around to functions because of their type parameter. Every user of _surf_ has to make these functions generic over the chosen HTTP client, even though only one should ever be used at a time. By exposing the names of the HTTP clients, _surf_ users can use the specific type instead of a trait-bound parameter.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`cargo +nightly test` passed on Linux x64. I am unsure how to get the hyper-client and wasm-client features to pass tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

`IsahcClient` is no longer `Default`, but this didn't seem to be used anyway.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/rustasync/tide/blob/master/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
