### PR TITLE
Add method to get the request body

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -558,6 +558,11 @@ impl<C: HttpClient> Request<C> {
     pub fn request(&self) -> Option<&http_client::Request> {
         self.req.as_ref()
     }
+
+    /// Get a mutable HTTP request
+    pub fn request_mut(&mut self) -> Option<&mut http_client::Request> {
+        self.req.as_mut()
+    }
 }
 
 impl<C: HttpClient> Future for Request<C> {

--- a/src/request.rs
+++ b/src/request.rs
@@ -2,8 +2,8 @@ use futures::future::BoxFuture;
 use futures::prelude::*;
 use http::Method;
 use mime::Mime;
-use serde::Serialize;
 use serde::de::DeserializeOwned;
+use serde::Serialize;
 use url::Url;
 
 use crate::headers::Headers;
@@ -491,7 +491,6 @@ impl<C: HttpClient> Request<C> {
 
         Ok(body)
     }
-
 
     /// Read body in String
     /// # Examples

--- a/src/request.rs
+++ b/src/request.rs
@@ -529,13 +529,13 @@ impl<C: HttpClient> Request<C> {
     /// assert_eq!(json, data);
     /// # Ok(()) }
     /// ```
-    pub async fn read_body_to_json<T: DeserializeOwned>(&mut self) -> std::io::Result<T> {
+    pub async fn read_body_to_json<T: DeserializeOwned>(&mut self) -> Result<T, Exception> {
         let req = self.request_mut().unwrap();
 
         let mut bytes = Vec::new();
         req.body_mut().read_to_end(&mut bytes).await?;
 
-        Ok(serde_json::from_slice(&bytes).map_err(|_| std::io::ErrorKind::InvalidData)?)
+        Ok(serde_json::from_slice(&bytes)?)
     }
 
     /// Submit the request and get the response body as bytes.

--- a/src/request.rs
+++ b/src/request.rs
@@ -491,6 +491,28 @@ impl<C: HttpClient> Request<C> {
         Ok(body)
     }
 
+
+    /// Read body in String
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # #[runtime::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+    /// let uri = "https://httpbin.org/post";
+    /// let data = "hello".to_string();
+    /// let mut req = surf::post(uri).body_string(data);
+    ///
+    /// assert_eq!(req.read_body_to_string().await?, "hello".to_string());
+    /// # Ok(()) }
+    /// ```
+    pub async fn read_body_to_string(&mut self) -> Result<String, Exception> {
+        let req = self.request_mut().unwrap();
+
+        let mut bytes = Vec::new();
+        req.body_mut().read_to_end(&mut bytes).await?;
+
+        Ok(String::from_utf8(bytes).map_err(|_| io::Error::from(io::ErrorKind::InvalidData))?)
+    }
     /// Submit the request and get the response body as bytes.
     ///
     /// # Examples

--- a/src/request.rs
+++ b/src/request.rs
@@ -469,6 +469,28 @@ impl<C: HttpClient> Request<C> {
         Ok(self)
     }
 
+    /// Read body in String
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # #[runtime::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+    /// let uri = "https://httpbin.org/post";
+    /// let data = "hello".to_string();
+    /// let mut req = surf::post(uri).body_string(data);
+    ///
+    /// assert_eq!(req.read_body_to_bytes().await?, "hello".as_bytes());
+    /// # Ok(()) }
+    /// ```
+    pub async fn read_body_to_bytes(&mut self) -> Result<Vec<u8>, Exception> {
+        let req = self.request_mut().unwrap();
+
+        let mut body = Vec::new();
+        req.body_mut().read_to_end(&mut body).await?;
+
+        Ok(body)
+    }
+
     /// Submit the request and get the response body as bytes.
     ///
     /// # Examples


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
close: https://github.com/rustasync/surf/issues/67

Currently there seems to be no method to get the request body.
So I added it.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/rustasync/tide/blob/master/.github/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
