### PR TITLE
Remove runtime and use async-std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ features = [
 ]
 
 [dev-dependencies]
+async-std = "0.99.10"
 femme = "1.1.0"
 runtime = "0.3.0-alpha.6"
 serde = { version = "1.0.97", features = ["derive"] }

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -1,12 +1,12 @@
-type Exception = Box<dyn std::error::Error + Send + Sync + 'static>;
+use async_std::task;
 
-#[runtime::main]
-async fn main() -> Result<(), Exception> {
-    femme::start(log::LevelFilter::Info)?;
+fn main()  {
+    femme::start(log::LevelFilter::Info);
 
-    let uri = "https://httpbin.org/get";
-    let string = surf::get(uri).recv_string().await?;
-    println!("{}", string);
-
-    Ok(())
+    task::block_on(async {
+        let uri = "https://httpbin.org/get";
+        let string = surf::get(uri).recv_string().await;
+        println!("{}", string.unwrap());
+    });
+    ()
 }

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -1,12 +1,15 @@
-type Exception = Box<dyn std::error::Error + Send + Sync + 'static>;
 use async_std::task;
 
-fn main()  {
+// The need for Ok with turbofish is explained here
+// https://rust-lang.github.io/async-book/07_workarounds/03_err_in_async_blocks.html
+fn main() -> Result<(), surf::Exception> {
     femme::start(log::LevelFilter::Info);
 
     task::block_on(async {
         let uri = "https://httpbin.org/get";
-        let string = surf::get(uri).recv_string().await;
-        println!("{}", string.unwrap());
-    })
+        let string: String = surf::get(uri).recv_string().await?;
+        println!("{}", string);
+        Ok::<(), surf::Exception>(())
+    });
+    Ok(())
 }

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -1,3 +1,4 @@
+type Exception = Box<dyn std::error::Error + Send + Sync + 'static>;
 use async_std::task;
 
 fn main()  {
@@ -7,6 +8,5 @@ fn main()  {
         let uri = "https://httpbin.org/get";
         let string = surf::get(uri).recv_string().await;
         println!("{}", string.unwrap());
-    });
-    ()
+    })
 }

--- a/examples/middleware.rs
+++ b/examples/middleware.rs
@@ -19,11 +19,15 @@ impl<C: HttpClient> Middleware<C> for Printer {
     }
 }
 
-#[runtime::main]
-async fn main() -> Result<(), surf::Exception> {
-    femme::start(log::LevelFilter::Info)?;
-    surf::get("https://httpbin.org/get")
-        .middleware(Printer {})
-        .await?;
-    Ok(())
+use async_std::task;
+
+fn main() {
+    femme::start(log::LevelFilter::Info);
+
+    task::block_on(async {
+        surf::get("https://httpbin.org/get")
+            .middleware(Printer {})
+            .await.unwrap();
+    });
+    ()
 }

--- a/examples/middleware.rs
+++ b/examples/middleware.rs
@@ -28,6 +28,5 @@ fn main() {
         surf::get("https://httpbin.org/get")
             .middleware(Printer {})
             .await.unwrap();
-    });
-    ()
+    })
 }

--- a/examples/middleware.rs
+++ b/examples/middleware.rs
@@ -1,4 +1,5 @@
 use futures::future::BoxFuture;
+use async_std::task;
 use surf::middleware::{HttpClient, Middleware, Next, Request, Response};
 
 struct Printer;
@@ -19,14 +20,15 @@ impl<C: HttpClient> Middleware<C> for Printer {
     }
 }
 
-use async_std::task;
-
-fn main() {
+// The need for Ok with turbofish is explained here
+// https://rust-lang.github.io/async-book/07_workarounds/03_err_in_async_blocks.html
+fn main() -> Result<(), surf::Exception> {
     femme::start(log::LevelFilter::Info);
 
     task::block_on(async {
         surf::get("https://httpbin.org/get")
             .middleware(Printer {})
-            .await.unwrap();
+            .await?;
+        Ok::<(), surf::Exception>(())
     })
 }

--- a/examples/next_reuse.rs
+++ b/examples/next_reuse.rs
@@ -1,3 +1,4 @@
+use async_std::task;
 use futures::future::BoxFuture;
 use futures::io::AsyncReadExt;
 use surf::middleware::{Body, HttpClient, Middleware, Next, Request, Response};
@@ -40,15 +41,15 @@ impl<C: HttpClient> Middleware<C> for Doubler {
     }
 }
 
-#[runtime::main]
-async fn main() -> Result<(), surf::Exception> {
-    femme::start(log::LevelFilter::Info)?;
-    let mut res = surf::get("https://httpbin.org/get")
-        .middleware(Doubler {})
-        .await?;
-    dbg!(&res);
-    let body = res.body_bytes().await?;
-    let body = String::from_utf8_lossy(&body);
-    println!("{}", body);
-    Ok(())
+fn main() {
+    femme::start(log::LevelFilter::Info).unwrap();
+    task::block_on(async {
+        let mut res = surf::get("https://httpbin.org/get")
+            .middleware(Doubler {})
+            .await.unwrap();
+        dbg!(&res);
+        let body = res.body_bytes().await.unwrap();
+        let body = String::from_utf8_lossy(&body);
+        println!("{}", body);
+    })
 }

--- a/examples/next_reuse.rs
+++ b/examples/next_reuse.rs
@@ -41,15 +41,18 @@ impl<C: HttpClient> Middleware<C> for Doubler {
     }
 }
 
-fn main() {
+// The need for Ok with turbofish is explained here
+// https://rust-lang.github.io/async-book/07_workarounds/03_err_in_async_blocks.html
+fn main() -> Result<(), surf::Exception> {
     femme::start(log::LevelFilter::Info).unwrap();
     task::block_on(async {
         let mut res = surf::get("https://httpbin.org/get")
             .middleware(Doubler {})
-            .await.unwrap();
+            .await?;
         dbg!(&res);
-        let body = res.body_bytes().await.unwrap();
+        let body = res.body_bytes().await?;
         let body = String::from_utf8_lossy(&body);
         println!("{}", body);
+        Ok::<(), surf::Exception>(())
     })
 }

--- a/examples/persistent.rs
+++ b/examples/persistent.rs
@@ -1,11 +1,14 @@
 use async_std::task;
 
-fn main() {
+// The need for Ok with turbofish is explained here
+// https://rust-lang.github.io/async-book/07_workarounds/03_err_in_async_blocks.html
+fn main() -> Result<(), surf::Exception> {
     femme::start(log::LevelFilter::Info).unwrap();
     task::block_on(async {
         let client = surf::Client::new();
         let req1 = client.get("https://httpbin.org/get").recv_string();
         let req2 = client.get("https://httpbin.org/get").recv_string();
-        futures::future::try_join(req1, req2).await.unwrap();
+        futures::future::try_join(req1, req2).await?;
+        Ok::<(), surf::Exception>(())
     })
 }

--- a/examples/persistent.rs
+++ b/examples/persistent.rs
@@ -1,11 +1,11 @@
-type Exception = Box<dyn std::error::Error + Send + Sync + 'static>;
+use async_std::task;
 
-#[runtime::main]
-async fn main() -> Result<(), Exception> {
-    femme::start(log::LevelFilter::Info)?;
-    let client = surf::Client::new();
-    let req1 = client.get("https://httpbin.org/get").recv_string();
-    let req2 = client.get("https://httpbin.org/get").recv_string();
-    futures::future::try_join(req1, req2).await?;
-    Ok(())
+fn main() {
+    femme::start(log::LevelFilter::Info).unwrap();
+    task::block_on(async {
+        let client = surf::Client::new();
+        let req1 = client.get("https://httpbin.org/get").recv_string();
+        let req2 = client.get("https://httpbin.org/get").recv_string();
+        futures::future::try_join(req1, req2).await.unwrap();
+    })
 }

--- a/examples/post.rs
+++ b/examples/post.rs
@@ -1,11 +1,14 @@
 use async_std::task;
 
-fn main() {
+// The need for Ok with turbofish is explained here
+// https://rust-lang.github.io/async-book/07_workarounds/03_err_in_async_blocks.html
+fn main() -> Result<(), surf::Exception> {
     femme::start(log::LevelFilter::Info).unwrap();
     task::block_on(async {
         let uri = "https://httpbin.org/post";
         let data = serde_json::json!({ "name": "chashu" });
-        let res = surf::post(uri).body_json(&data).unwrap().await.unwrap();
+        let res = surf::post(uri).body_json(&data).unwrap().await?;
         assert_eq!(res.status(), 200);
+        Ok::<(), surf::Exception>(())
     })
 }

--- a/examples/post.rs
+++ b/examples/post.rs
@@ -1,9 +1,11 @@
-#[runtime::main]
-async fn main() -> Result<(), surf::Exception> {
-    femme::start(log::LevelFilter::Info)?;
-    let uri = "https://httpbin.org/post";
-    let data = serde_json::json!({ "name": "chashu" });
-    let res = surf::post(uri).body_json(&data)?.await?;
-    assert_eq!(res.status(), 200);
-    Ok(())
+use async_std::task;
+
+fn main() {
+    femme::start(log::LevelFilter::Info).unwrap();
+    task::block_on(async {
+        let uri = "https://httpbin.org/post";
+        let data = serde_json::json!({ "name": "chashu" });
+        let res = surf::post(uri).body_json(&data).unwrap().await.unwrap();
+        assert_eq!(res.status(), 200);
+    })
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The runtime library is no longer being updated, so I changed it to `async-std`.

## Motivation and Context

When trying to do the github-sdk, I got into a lot of troubles when starting with the crate. I was trying to follow other examples but they all used the `runtime` library. 

## How Has This Been Tested?

I have changed the code to fit with what I understand to be the way this would be done using `async_std`, using `tasks`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/rustasync/tide/blob/master/.github/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
