### PR TITLE
1.0.3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,15 +66,3 @@ jobs:
 
     - name: Docs
       run: cargo doc
-
-  clippy_check:
-    name: Clippy check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - name: Install rust
-        run: rustup update beta && rustup default beta
-      - name: Install clippy
-        run: rustup component add clippy
-      - name: clippy
-        run: cargo clippy --all

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,144 +1,38 @@
-## 2019-08-15, Version 1.0.1
-### Commits
-- [[`d7d9d054aa`](https://github.com/http-rs/surf/commit/d7d9d054aad0a9bc46a7d177e133770c25451c6a)] (cargo-release) version 1.0.1 (Yoshua Wuyts)
-- [[`708746439e`](https://github.com/http-rs/surf/commit/708746439e8ec21ec08f7819dbdbcb6849a6b465)] change first line (Yoshua Wuyts)
-- [[`013a665fbc`](https://github.com/http-rs/surf/commit/013a665fbc65dd360efd71bc2d3318e2ef2e3fa1)] break in readme (Yoshua Wuyts)
-- [[`779822211e`](https://github.com/http-rs/surf/commit/779822211e1f9157826fb2d96b7fbd819ecb40a3)] final polish (Yoshua Wuyts)
-- [[`3c76ae60b0`](https://github.com/http-rs/surf/commit/3c76ae60b08e5370b47f6ecc7be205cdad5fedaf)] fix attr in readme (Yoshua Wuyts)
-- [[`7ecd05f84f`](https://github.com/http-rs/surf/commit/7ecd05f84f95b1bc17bb855baa60c2bdfbefc1df)] better examples (Yoshua Wuyts)
-- [[`729731cddf`](https://github.com/http-rs/surf/commit/729731cddf0648de069afb633a9c7b6078a61560)] reword readme (Yoshua Wuyts)
-- [[`5341966814`](https://github.com/http-rs/surf/commit/534196681426ecfce5c2ab3f84e7403d763a1963)] shout outs (Yoshua Wuyts)
-- [[`ff071d79f4`](https://github.com/http-rs/surf/commit/ff071d79f41b1aea1440cfe55c64e4948da868fc)] Final polish (#30) (Yoshua Wuyts)
-- [[`00e53514eb`](https://github.com/http-rs/surf/commit/00e53514ebab0c778570537e0336ee35143d7ce6)] WASM backend (#25) (Yoshua Wuyts)
-- [[`94d2bc6c08`](https://github.com/http-rs/surf/commit/94d2bc6c080b75da8f133574760ce4757daaf066)] simplify body creation (Yoshua Wuyts)
-- [[`c4b00b58e1`](https://github.com/http-rs/surf/commit/c4b00b58e1ab7de1a68e6af9df70de756f2e3026)] update examples (Yoshua Wuyts)
-- [[`680b3bae5c`](https://github.com/http-rs/surf/commit/680b3bae5c6c27c0a2ad8c31e07cf0dcc8a4e31d)] Query + Form (#23) (Yoshua Wuyts)
-- [[`83e00e441f`](https://github.com/http-rs/surf/commit/83e00e441f1312fa830e611f431660c24e1a8aeb)] Examples (#22) (Yoshua Wuyts)
-- [[`fd187a033c`](https://github.com/http-rs/surf/commit/fd187a033c19399ce9b0543f6147cea655a83479)] chttp backend (#17) (Yoshua Wuyts)
-- [[`d17a461940`](https://github.com/http-rs/surf/commit/d17a4619407cd017a66479463fa75c33972994f8)] Methods (#15) (Yoshua Wuyts)
-- [[`a46b1d701a`](https://github.com/http-rs/surf/commit/a46b1d701abb24427435bd7a4007270029575db1)] enable logging middleware by default (#13) (Yoshua Wuyts)
-- [[`ae95c5debc`](https://github.com/http-rs/surf/commit/ae95c5debcda92ab7e1a9b7bd93b37aca42509c6)] implements From and Into impls for the http types (#12) (Yoshua Wuyts)
-- [[`fa038b8344`](https://github.com/http-rs/surf/commit/fa038b83448cb5dd11ccdc3c77c8e02adc078452)] Try post (#11) (Yoshua Wuyts)
-- [[`4c6460c05d`](https://github.com/http-rs/surf/commit/4c6460c05dfd5c86658362b1362390b1297c5111)] Custom connection (#9) (Yoshua Wuyts)
-- [[`926d28d224`](https://github.com/http-rs/surf/commit/926d28d2241554482199a34a254840c94d065b7c)] Client (#7) (Yoshua Wuyts)
-- [[`8f1916bc4c`](https://github.com/http-rs/surf/commit/8f1916bc4cd95a77738661fa28df637d2bf10f19)] Polish (#6) (Yoshua Wuyts)
-- [[`8526c3c3df`](https://github.com/http-rs/surf/commit/8526c3c3dfb804edfa11139d2ec1b72bfbaefff8)] Middleware (#5) (Yoshua Wuyts)
-- [[`6c9629ae94`](https://github.com/http-rs/surf/commit/6c9629ae94a3b5396e556bc8109eff27e41a8ec9)] add into_json method (Yoshua Wuyts)
-- [[`dd8bfab8e8`](https://github.com/http-rs/surf/commit/dd8bfab8e85c95495b0b2c6a043faef4fd7f557f)] insert a header type (Yoshua Wuyts)
-- [[`4629cf3b61`](https://github.com/http-rs/surf/commit/4629cf3b618c6e3ef64cf0dc2f8487a0255127f0)] fmt and remove dead code (Yoshua Wuyts)
-- [[`1eecdff217`](https://github.com/http-rs/surf/commit/1eecdff217f05ed042b00051874b4590ae88da7c)] this is the hell patch (Yoshua Wuyts)
-- [[`2eea0f5bfe`](https://github.com/http-rs/surf/commit/2eea0f5bfe5b61daeb5a20d7b6d1ed35ed5d235e)] split into modules (Yoshua Wuyts)
-- [[`69b9ee0a77`](https://github.com/http-rs/surf/commit/69b9ee0a775e665da1b6ca3a7131169d7490d14a)] placeholders (Yoshua Wuyts)
-- [[`b3de372c93`](https://github.com/http-rs/surf/commit/b3de372c93b3336e3c09b40515047a3ef8a3b3f6)] it works! (Yoshua Wuyts)
-- [[`04088ef363`](https://github.com/http-rs/surf/commit/04088ef36315d59994c246cd46c6849d97260bd7)] update (Yoshua Wuyts)
-- [[`37e948b297`](https://github.com/http-rs/surf/commit/37e948b297eb624e483ec69c32358a88dedb169f)] google example (Yoshua Wuyts)
-- [[`bb3911d2f0`](https://github.com/http-rs/surf/commit/bb3911d2f06c9d3d899916e5490b63bd81844c50)] futures dep (Yoshua Wuyts)
-- [[`226b0f71b4`](https://github.com/http-rs/surf/commit/226b0f71b4e7ed600f74ff69fe466f193ad8f60e)] init http client (Yoshua Wuyts)
-- [[`39279a9fee`](https://github.com/http-rs/surf/commit/39279a9fee93d1647418e159cf127c97e219dd98)] see also (Yoshua Wuyts)
-- [[`38d9071a00`](https://github.com/http-rs/surf/commit/38d9071a00b7d4004860f32b7ecf61f3916b2578)] . (Yoshua Wuyts)
+# Changelog
 
-### Stats
-```diff
- .travis.yml                     |  4 +-
- CHANGELOG.md                    | 74 +------------------------------------------
- Cargo.toml                      | 10 +++---
- README.md                       |  8 +++--
- examples/hello_world.rs         |  1 +-
- examples/middleware.rs          |  4 +-
- examples/next_reuse.rs          | 54 +-------------------------------
- examples/persistent.rs          |  1 +-
- examples/post.rs                |  2 +-
- src/client.rs                   | 13 ++++++-
- src/headers.rs                  |  6 +--
- src/http_client/chttp.rs        | 48 +++++++++++++++++++++++++++-
- src/http_client/isahc.rs        | 54 +-------------------------------
- src/http_client/mod.rs          |  2 +-
- src/http_client/native.rs       |  2 +-
- src/http_client/wasm.rs         | 13 ++-----
- src/lib.rs                      |  5 +++-
- src/middleware/logger/mod.rs    |  2 +-
- src/middleware/logger/native.rs |  6 +--
- src/middleware/logger/wasm.rs   |  5 +--
- src/middleware/mod.rs           | 13 +------
- src/one_off.rs                  | 11 +++++-
- src/request.rs                  | 55 +++++++++++++++----------------
- src/response.rs                 | 11 +++++-
- tests/test.rs                   |  2 +-
- 25 files changed, 155 insertions(+), 251 deletions(-)
-```
+All notable changes to surf will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://book.async.rs/overview/stability-guarantees.html).
+
+## [Unreleased]
+
+## [1.0.3] - 2019-11-07
+
+### Changed
+
+- Migrated the project from the `rustasync` organization to `http-rs`.
+- Migrated CI providers from Travis CI to GitHub Actions.
+- Replaced `runtime` with `async-std` in examples.
+- Error context no longer discards the inner error body.
+- Updated the README.md formatting.
+- Updated `futures-preview` to `0.3.0-alpha.19`
+
+## [1.0.2] - 2019-08-26
+
+Log not kept.
+
+## [1.0.1] - 2019-08-15
+
+Log not kept.
 
 
-## 2019-08-15, Version 1.0.1
-### Commits
-- [[`d7d9d054aa`](https://github.com/http-rs/surf/commit/d7d9d054aad0a9bc46a7d177e133770c25451c6a)] (cargo-release) version 1.0.1 (Yoshua Wuyts)
-- [[`708746439e`](https://github.com/http-rs/surf/commit/708746439e8ec21ec08f7819dbdbcb6849a6b465)] change first line (Yoshua Wuyts)
-- [[`013a665fbc`](https://github.com/http-rs/surf/commit/013a665fbc65dd360efd71bc2d3318e2ef2e3fa1)] break in readme (Yoshua Wuyts)
-- [[`779822211e`](https://github.com/http-rs/surf/commit/779822211e1f9157826fb2d96b7fbd819ecb40a3)] final polish (Yoshua Wuyts)
-- [[`3c76ae60b0`](https://github.com/http-rs/surf/commit/3c76ae60b08e5370b47f6ecc7be205cdad5fedaf)] fix attr in readme (Yoshua Wuyts)
-- [[`7ecd05f84f`](https://github.com/http-rs/surf/commit/7ecd05f84f95b1bc17bb855baa60c2bdfbefc1df)] better examples (Yoshua Wuyts)
-- [[`729731cddf`](https://github.com/http-rs/surf/commit/729731cddf0648de069afb633a9c7b6078a61560)] reword readme (Yoshua Wuyts)
-- [[`5341966814`](https://github.com/http-rs/surf/commit/534196681426ecfce5c2ab3f84e7403d763a1963)] shout outs (Yoshua Wuyts)
-- [[`ff071d79f4`](https://github.com/http-rs/surf/commit/ff071d79f41b1aea1440cfe55c64e4948da868fc)] Final polish (#30) (Yoshua Wuyts)
-- [[`00e53514eb`](https://github.com/http-rs/surf/commit/00e53514ebab0c778570537e0336ee35143d7ce6)] WASM backend (#25) (Yoshua Wuyts)
-- [[`94d2bc6c08`](https://github.com/http-rs/surf/commit/94d2bc6c080b75da8f133574760ce4757daaf066)] simplify body creation (Yoshua Wuyts)
-- [[`c4b00b58e1`](https://github.com/http-rs/surf/commit/c4b00b58e1ab7de1a68e6af9df70de756f2e3026)] update examples (Yoshua Wuyts)
-- [[`680b3bae5c`](https://github.com/http-rs/surf/commit/680b3bae5c6c27c0a2ad8c31e07cf0dcc8a4e31d)] Query + Form (#23) (Yoshua Wuyts)
-- [[`83e00e441f`](https://github.com/http-rs/surf/commit/83e00e441f1312fa830e611f431660c24e1a8aeb)] Examples (#22) (Yoshua Wuyts)
-- [[`fd187a033c`](https://github.com/http-rs/surf/commit/fd187a033c19399ce9b0543f6147cea655a83479)] chttp backend (#17) (Yoshua Wuyts)
-- [[`d17a461940`](https://github.com/http-rs/surf/commit/d17a4619407cd017a66479463fa75c33972994f8)] Methods (#15) (Yoshua Wuyts)
-- [[`a46b1d701a`](https://github.com/http-rs/surf/commit/a46b1d701abb24427435bd7a4007270029575db1)] enable logging middleware by default (#13) (Yoshua Wuyts)
-- [[`ae95c5debc`](https://github.com/http-rs/surf/commit/ae95c5debcda92ab7e1a9b7bd93b37aca42509c6)] implements From and Into impls for the http types (#12) (Yoshua Wuyts)
-- [[`fa038b8344`](https://github.com/http-rs/surf/commit/fa038b83448cb5dd11ccdc3c77c8e02adc078452)] Try post (#11) (Yoshua Wuyts)
-- [[`4c6460c05d`](https://github.com/http-rs/surf/commit/4c6460c05dfd5c86658362b1362390b1297c5111)] Custom connection (#9) (Yoshua Wuyts)
-- [[`926d28d224`](https://github.com/http-rs/surf/commit/926d28d2241554482199a34a254840c94d065b7c)] Client (#7) (Yoshua Wuyts)
-- [[`8f1916bc4c`](https://github.com/http-rs/surf/commit/8f1916bc4cd95a77738661fa28df637d2bf10f19)] Polish (#6) (Yoshua Wuyts)
-- [[`8526c3c3df`](https://github.com/http-rs/surf/commit/8526c3c3dfb804edfa11139d2ec1b72bfbaefff8)] Middleware (#5) (Yoshua Wuyts)
-- [[`6c9629ae94`](https://github.com/http-rs/surf/commit/6c9629ae94a3b5396e556bc8109eff27e41a8ec9)] add into_json method (Yoshua Wuyts)
-- [[`dd8bfab8e8`](https://github.com/http-rs/surf/commit/dd8bfab8e85c95495b0b2c6a043faef4fd7f557f)] insert a header type (Yoshua Wuyts)
-- [[`4629cf3b61`](https://github.com/http-rs/surf/commit/4629cf3b618c6e3ef64cf0dc2f8487a0255127f0)] fmt and remove dead code (Yoshua Wuyts)
-- [[`1eecdff217`](https://github.com/http-rs/surf/commit/1eecdff217f05ed042b00051874b4590ae88da7c)] this is the hell patch (Yoshua Wuyts)
-- [[`2eea0f5bfe`](https://github.com/http-rs/surf/commit/2eea0f5bfe5b61daeb5a20d7b6d1ed35ed5d235e)] split into modules (Yoshua Wuyts)
-- [[`69b9ee0a77`](https://github.com/http-rs/surf/commit/69b9ee0a775e665da1b6ca3a7131169d7490d14a)] placeholders (Yoshua Wuyts)
-- [[`b3de372c93`](https://github.com/http-rs/surf/commit/b3de372c93b3336e3c09b40515047a3ef8a3b3f6)] it works! (Yoshua Wuyts)
-- [[`04088ef363`](https://github.com/http-rs/surf/commit/04088ef36315d59994c246cd46c6849d97260bd7)] update (Yoshua Wuyts)
-- [[`37e948b297`](https://github.com/http-rs/surf/commit/37e948b297eb624e483ec69c32358a88dedb169f)] google example (Yoshua Wuyts)
-- [[`bb3911d2f0`](https://github.com/http-rs/surf/commit/bb3911d2f06c9d3d899916e5490b63bd81844c50)] futures dep (Yoshua Wuyts)
-- [[`226b0f71b4`](https://github.com/http-rs/surf/commit/226b0f71b4e7ed600f74ff69fe466f193ad8f60e)] init http client (Yoshua Wuyts)
-- [[`39279a9fee`](https://github.com/http-rs/surf/commit/39279a9fee93d1647418e159cf127c97e219dd98)] see also (Yoshua Wuyts)
-- [[`38d9071a00`](https://github.com/http-rs/surf/commit/38d9071a00b7d4004860f32b7ecf61f3916b2578)] . (Yoshua Wuyts)
+## [1.0.0] - 2019-08-15
 
-### Stats
-```diff
- .github/CODE_OF_CONDUCT.md      |  75 +++++-
- .github/CONTRIBUTING.md         |  55 ++++-
- .gitignore                      |   8 +-
- .travis.yml                     |  15 +-
- Cargo.toml                      |  72 +++++-
- LICENSE-APACHE                  | 190 +++++++++++++-
- LICENSE-MIT                     |  21 +-
- README.md                       | 167 +++++++++++-
- examples/browser.rs             |  11 +-
- examples/hello_world.rs         |  13 +-
- examples/middleware.rs          |  31 ++-
- examples/persistent.rs          |  12 +-
- examples/post.rs                |  11 +-
- src/client.rs                   | 278 +++++++++++++++++++-
- src/headers.rs                  |  56 ++++-
- src/http_client/chttp.rs        |  48 +++-
- src/http_client/hyper.rs        | 161 +++++++++++-
- src/http_client/mod.rs          | 110 +++++++-
- src/http_client/native.rs       |   5 +-
- src/http_client/wasm.rs         | 201 +++++++++++++-
- src/lib.rs                      | 104 +++++++-
- src/middleware/logger/mod.rs    |  44 +++-
- src/middleware/logger/native.rs | 123 ++++++++-
- src/middleware/logger/wasm.rs   | 108 +++++++-
- src/middleware/mod.rs           | 123 ++++++++-
- src/one_off.rs                  | 364 ++++++++++++++++++++++++-
- src/request.rs                  | 616 +++++++++++++++++++++++++++++++++++++++++-
- src/response.rs                 | 257 +++++++++++++++++-
- tests/test.rs                   |  32 ++-
- 29 files changed, 3311 insertions(+)
-```
+Log not kept.
 
-
+[Unreleased]: https://github.com/http-rs/tide/compare/v1.0.3...HEAD
+[1.0.3]: https://github.com/http-rs/tide/compare/v1.0.2...v1.0.3
+[1.0.2]: https://github.com/http-rs/tide/compare/v1.0.1...v1.0.2
+[1.0.1]: https://github.com/http-rs/tide/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/http-rs/tide/compare/v1.0.0


### PR DESCRIPTION
Prepare release for 1.0.3. Currently `surf` is broken. This does not update us to `futures 0.3.0` since that's a breaking change. There are a few other breaking changes we to do in tandem with that. Thanks!