### PR TITLE
Use appropriate charset in `body_string()`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,13 @@ readme = "README.md"
 edition = "2018"
 
 [features]
-default = ["native-client", "middleware-logger"]
+default = ["native-client", "middleware-logger", "encoding"]
 native-client = ["curl-client", "wasm-client"]
 hyper-client = ["hyper", "runtime", "runtime-raw", "runtime-tokio" ]
 curl-client = ["isahc"]
 wasm-client = ["js-sys", "web-sys", "wasm-bindgen", "wasm-bindgen-futures"]
 middleware-logger = []
+encoding = ["encoding_rs"]
 
 [dependencies]
 futures-preview = { version = "0.3.0-alpha.19", features = ["compat", "io-compat"] }
@@ -30,8 +31,11 @@ serde_json = "1.0.40"
 serde_urlencoded = "0.6.1"
 url = "2.0.0"
 
-# isahc-client
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+# encoding
+encoding_rs = { version = "0.8.20", optional = true }
+
+# isahc-client
 isahc = { version = "0.7", optional = true, default-features = false, features = ["http2"]  }
 
 # hyper-client
@@ -63,6 +67,7 @@ features = [
     "RequestMode",
     "RequestRedirect",
     "Response",
+    "TextDecoder",
     "Window",
 ]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,7 @@ pub use url;
 
 pub use client::Client;
 pub use request::Request;
-pub use response::Response;
+pub use response::{DecodeError, Response};
 
 #[cfg(feature = "native-client")]
 mod one_off;

--- a/src/response.rs
+++ b/src/response.rs
@@ -282,10 +282,10 @@ impl std::error::Error for DecodeError {}
 /// `std::io::ErrorKind::InvalidData`, carrying a `DecodeError` struct.
 #[cfg(not(feature = "encoding"))]
 fn decode_body(bytes: Vec<u8>, _content_encoding: Option<&str>) -> Result<String, Exception> {
-    Ok(String::from_utf8(bytes).map_err(|_| {
+    Ok(String::from_utf8(bytes).map_err(|err| {
         let err = DecodeError {
             encoding: "UTF-8".to_string(),
-            data: bytes,
+            data: err.into_bytes(),
         };
         io::Error::new(io::ErrorKind::InvalidData, err)
     })?)

--- a/src/response.rs
+++ b/src/response.rs
@@ -144,12 +144,21 @@ impl Response {
     /// This method can be called after the body has already been read, but will
     /// produce an empty buffer.
     ///
+    /// # Encodings
+    ///
+    /// If the "encoding" feature is enabled, this method tries to decode the body
+    /// with the encoding that is specified in the Content-Type header. If the header
+    /// does not specify an encoding, UTF-8 is assumed. If the "encoding" feature is
+    /// disabled, Surf only supports reading UTF-8 response bodies. The "encoding"
+    /// feature is enabled by default.
+    ///
     /// # Errors
     ///
     /// Any I/O error encountered while reading the body is immediately returned
     /// as an `Err`.
     ///
-    /// If the body cannot be interpreted as valid UTF-8, an `Err` is returned.
+    /// If the body cannot be interpreted because the encoding is unsupported or
+    /// incorrect, an `Err` is returned.
     ///
     /// # Examples
     ///

--- a/src/response.rs
+++ b/src/response.rs
@@ -257,12 +257,26 @@ impl fmt::Debug for Response {
 /// The error carries the encoding that was used to attempt to decode the body, and the raw byte
 /// contents of the body. This can be used to treat un-decodable bodies specially or to implement a
 /// fallback parsing strategy.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct DecodeError {
     /// The name of the encoding that was used to try to decode the input.
     pub encoding: String,
     /// The input data as bytes.
     pub data: Vec<u8>,
+}
+
+// Override debug output so you don't get each individual byte in `data` printed out separately,
+// because it can be many megabytes large. The actual content is not that interesting anyways
+// and can be accessed manually if it is required.
+impl fmt::Debug for DecodeError {
+    #[allow(missing_doc_code_examples)]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DecodeError")
+            .field("encoding", &self.encoding)
+            // Perhaps we can output the first N bytes of the response in the future
+            .field("data", &format!("{} bytes", self.data.len()))
+            .finish()
+    }
 }
 
 impl fmt::Display for DecodeError {


### PR DESCRIPTION
This is an initial attempt at addressing #101. Opening for comments—feel free to critique the direction etc and tell me to throw it all out if it's not what you're looking for! Leaving a few checkboxes…

A new default feature `"encoding"` opts in to using the appropriate character encoding.
- In native binaries, `encoding_rs` is used. If you know you're only talking to an API that always uses utf-8, you can turn off this feature and save the binary size that is taken up by the encoding tables.
- In WebAssembly, it calls out to the `TextDecoder` API. AFAIK This always makes a copy, so you can turn it off if you don't want to copy big strings between JS and wasm.
  - [x] We could optimize this for the utf-8 case by using `String::from_utf8()` directly if the charset is utf-8, and only use TextDecoder for other less common  encodings.

Turning off the `"encoding"` feature reverts to the current behaviour, which is assuming utf-8.
- [x] This should likely check that the charset is utf-8, and refuse to decode it if it is anything else, to avoid garbage output.

This patch also assumes utf-8 if no charset is specified in the response headers.
- [x] By spec the default encoding should be iso-8859-1, but in practice it's not. Need to figure out the best approach here.

This patch introduces an error type that's quite unlike anything Surf has right now, so I'm not sure if that direction fits in with the design. I also wrapped the new error type in an `io::ErrorKind::InvalidData` everywhere which is mostly cargo culting, I don't think that's actually necessary? I carried it over from the old `body_string()` implementation, where it _did_ make sense.
- [x] probably get rid of that wrapping