### PR TITLE
Futures 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,6 @@ features = [
 ]
 
 [dev-dependencies]
-async-std = "1.0"
+async-std = { version = "1.0", features = ["attributes"] }
 femme = "1.1.0"
-runtime = "0.3.0-alpha.8"
 serde = { version = "1.0.97", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 [features]
 default = ["native-client", "middleware-logger", "encoding"]
 native-client = ["curl-client", "wasm-client"]
-hyper-client = ["hyper", "runtime", "runtime-raw", "runtime-tokio" ]
+hyper-client = ["hyper", "hyper-tls", "native-tls", "runtime", "runtime-raw", "runtime-tokio" ]
 curl-client = ["isahc"]
 wasm-client = ["js-sys", "web-sys", "wasm-bindgen", "wasm-bindgen-futures"]
 middleware-logger = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ middleware-logger = []
 encoding = ["encoding_rs"]
 
 [dependencies]
-futures-preview = { version = "0.3.0-alpha.19", features = ["compat", "io-compat"] }
+futures = { version = "0.3.1", features = ["compat", "io-compat"] }
 http = "0.1.17"
 log = { version = "0.4.7", features = ["kv_unstable"] }
 mime = "0.3.13"
@@ -36,7 +36,7 @@ url = "2.0.0"
 encoding_rs = { version = "0.8.20", optional = true }
 
 # isahc-client
-isahc = { version = "0.7", optional = true, default-features = false, features = ["http2"]  }
+isahc = { version = "0.8", optional = true, default-features = false, features = ["http2"]  }
 
 # hyper-client
 hyper = { version = "0.12.32", optional = true, default-features = false }
@@ -50,7 +50,7 @@ runtime-tokio = { version = "0.3.0-alpha.5", optional = true }
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = { version = "0.3.25", optional = true }
 wasm-bindgen = { version = "0.2.48", optional = true }
-wasm-bindgen-futures = { version = "0.3.25", features = ["futures_0_3"], optional = true }
+wasm-bindgen-futures = { version = "0.4.5", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.web-sys]
 version = "0.3.25"
@@ -72,7 +72,7 @@ features = [
 ]
 
 [dev-dependencies]
-async-std = "0.99.10"
+async-std = "1.0"
 femme = "1.1.0"
-runtime = "0.3.0-alpha.6"
+runtime = "0.3.0-alpha.8"
 serde = { version = "1.0.97", features = ["derive"] }

--- a/src/client.rs
+++ b/src/client.rs
@@ -9,7 +9,7 @@ use super::http_client::native::NativeClient;
 /// # Examples
 ///
 /// ```no_run
-/// # #[runtime::main]
+/// # #[async_std::main]
 /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
 /// let client = surf::Client::new();
 /// let req1 = client.get("https://httpbin.org/get").recv_string();
@@ -29,7 +29,7 @@ impl Client<NativeClient> {
     /// # Examples
     ///
     /// ```no_run
-    /// # #[runtime::main]
+    /// # #[async_std::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     /// let client = surf::Client::new();
     /// # Ok(()) }
@@ -62,7 +62,7 @@ impl<C: HttpClient> Client<C> {
     /// # Examples
     ///
     /// ```no_run
-    /// # #[runtime::main]
+    /// # #[async_std::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     /// let client = surf::Client::new();
     /// let string = client.get("https://httpbin.org/get").recv_string().await?;
@@ -86,7 +86,7 @@ impl<C: HttpClient> Client<C> {
     /// # Examples
     ///
     /// ```no_run
-    /// # #[runtime::main]
+    /// # #[async_std::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     /// let client = surf::Client::new();
     /// let string = client.head("https://httpbin.org/head").recv_string().await?;
@@ -110,7 +110,7 @@ impl<C: HttpClient> Client<C> {
     /// # Examples
     ///
     /// ```no_run
-    /// # #[runtime::main]
+    /// # #[async_std::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     /// let client = surf::Client::new();
     /// let string = client.post("https://httpbin.org/post").recv_string().await?;
@@ -134,7 +134,7 @@ impl<C: HttpClient> Client<C> {
     /// # Examples
     ///
     /// ```no_run
-    /// # #[runtime::main]
+    /// # #[async_std::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     /// let client = surf::Client::new();
     /// let string = client.put("https://httpbin.org/put").recv_string().await?;
@@ -158,7 +158,7 @@ impl<C: HttpClient> Client<C> {
     /// # Examples
     ///
     /// ```no_run
-    /// # #[runtime::main]
+    /// # #[async_std::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     /// let client = surf::Client::new();
     /// let string = client.delete("https://httpbin.org/delete").recv_string().await?;
@@ -182,7 +182,7 @@ impl<C: HttpClient> Client<C> {
     /// # Examples
     ///
     /// ```no_run
-    /// # #[runtime::main]
+    /// # #[async_std::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     /// let client = surf::Client::new();
     /// let string = client.connect("https://httpbin.org/connect").recv_string().await?;
@@ -206,7 +206,7 @@ impl<C: HttpClient> Client<C> {
     /// # Examples
     ///
     /// ```no_run
-    /// # #[runtime::main]
+    /// # #[async_std::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     /// let client = surf::Client::new();
     /// let string = client.options("https://httpbin.org/options").recv_string().await?;
@@ -230,7 +230,7 @@ impl<C: HttpClient> Client<C> {
     /// # Examples
     ///
     /// ```no_run
-    /// # #[runtime::main]
+    /// # #[async_std::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     /// let client = surf::Client::new();
     /// let string = client.trace("https://httpbin.org/trace").recv_string().await?;
@@ -254,7 +254,7 @@ impl<C: HttpClient> Client<C> {
     /// # Examples
     ///
     /// ```no_run
-    /// # #[runtime::main]
+    /// # #[async_std::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     /// let client = surf::Client::new();
     /// let string = client.patch("https://httpbin.org/patch").recv_string().await?;

--- a/src/http_client/mod.rs
+++ b/src/http_client/mod.rs
@@ -1,6 +1,6 @@
 //! HTTP Client Interface
 use futures::future::BoxFuture;
-use futures::io::AsyncRead;
+use futures::io::{AsyncRead, Cursor};
 
 use std::error::Error;
 use std::fmt::{self, Debug};
@@ -96,7 +96,7 @@ impl From<Vec<u8>> for Body {
     #[inline]
     fn from(vec: Vec<u8>) -> Body {
         Self {
-            reader: Box::new(io::Cursor::new(vec)),
+            reader: Box::new(Cursor::new(vec)),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 //!
 //! # Examples
 //! ```no_run
-//! # #[runtime::main]
+//! # #[async_std::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
 //! let mut res = surf::get("https://httpbin.org/get").await?;
 //! dbg!(res.body_string().await?);
@@ -23,7 +23,7 @@
 //!
 //! It's also possible to skip the intermediate `Response`, and access the response type directly.
 //! ```no_run
-//! # #[runtime::main]
+//! # #[async_std::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
 //! dbg!(surf::get("https://httpbin.org/get").recv_string().await?);
 //! # Ok(()) }
@@ -32,7 +32,7 @@
 //! Both sending and receiving JSON is real easy too.
 //! ```no_run
 //! # use serde::{Deserialize, Serialize};
-//! # #[runtime::main]
+//! # #[async_std::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
 //! #[derive(Deserialize, Serialize)]
 //! struct Ip {
@@ -53,7 +53,7 @@
 //! And even creating streaming proxies is no trouble at all.
 //!
 //! ```no_run
-//! # #[runtime::main]
+//! # #[async_std::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
 //! let reader = surf::get("https://img.fyi/q6YvNqP").await?;
 //! let res = surf::post("https://box.rs/upload").body(reader).await?;

--- a/src/middleware/logger/mod.rs
+++ b/src/middleware/logger/mod.rs
@@ -3,7 +3,7 @@
 //! # Examples
 //!
 //! ```
-//! # #[runtime::main]
+//! # #[async_std::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
 //! let mut res = surf::get("https://httpbin.org/get")
 //!     .middleware(surf::middleware::logger::new())
@@ -29,7 +29,7 @@ use native::Logger;
 /// # Examples
 ///
 /// ```
-/// # #[runtime::main]
+/// # #[async_std::main]
 /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
 /// let mut res = surf::get("https://httpbin.org/get")
 ///     .middleware(surf::middleware::logger::new())

--- a/src/one_off.rs
+++ b/src/one_off.rs
@@ -25,7 +25,7 @@ use super::Request;
 /// # Examples
 ///
 /// ```no_run
-/// # #[runtime::main]
+/// # #[async_std::main]
 /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
 /// let string = surf::get("https://httpbin.org/get").recv_string().await?;
 /// # Ok(()) }
@@ -66,7 +66,7 @@ pub fn get(uri: impl AsRef<str>) -> Request<NativeClient> {
 /// # Examples
 ///
 /// ```no_run
-/// # #[runtime::main]
+/// # #[async_std::main]
 /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
 /// let string = surf::head("https://httpbin.org/head").recv_string().await?;
 /// # Ok(()) }
@@ -124,7 +124,7 @@ pub fn head(uri: impl AsRef<str>) -> Request<NativeClient> {
 /// # Examples
 ///
 /// ```no_run
-/// # #[runtime::main]
+/// # #[async_std::main]
 /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
 /// let string = surf::post("https://httpbin.org/post").recv_string().await?;
 /// # Ok(()) }
@@ -160,7 +160,7 @@ pub fn post(uri: impl AsRef<str>) -> Request<NativeClient> {
 /// # Examples
 ///
 /// ```no_run
-/// # #[runtime::main]
+/// # #[async_std::main]
 /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
 /// let string = surf::put("https://httpbin.org/put").recv_string().await?;
 /// # Ok(()) }
@@ -191,7 +191,7 @@ pub fn put(uri: impl AsRef<str>) -> Request<NativeClient> {
 /// # Examples
 ///
 /// ```no_run
-/// # #[runtime::main]
+/// # #[async_std::main]
 /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
 /// let string = surf::delete("https://httpbin.org/delete").recv_string().await?;
 /// # Ok(()) }
@@ -231,7 +231,7 @@ pub fn delete(uri: impl AsRef<str>) -> Request<NativeClient> {
 /// # Examples
 ///
 /// ```no_run
-/// # #[runtime::main]
+/// # #[async_std::main]
 /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
 /// let string = surf::connect("https://httpbin.org/connect").recv_string().await?;
 /// # Ok(()) }
@@ -264,7 +264,7 @@ pub fn connect(uri: impl AsRef<str>) -> Request<NativeClient> {
 /// # Examples
 ///
 /// ```no_run
-/// # #[runtime::main]
+/// # #[async_std::main]
 /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
 /// let string = surf::options("https://httpbin.org/options").recv_string().await?;
 /// # Ok(()) }
@@ -301,7 +301,7 @@ pub fn options(uri: impl AsRef<str>) -> Request<NativeClient> {
 /// # Examples
 ///
 /// ```no_run
-/// # #[runtime::main]
+/// # #[async_std::main]
 /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
 /// let string = surf::trace("https://httpbin.org/trace").recv_string().await?;
 /// # Ok(()) }
@@ -344,7 +344,7 @@ pub fn trace(uri: impl AsRef<str>) -> Request<NativeClient> {
 /// # Examples
 ///
 /// ```no_run
-/// # #[runtime::main]
+/// # #[async_std::main]
 /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
 /// let string = surf::patch("https://httpbin.org/patch").recv_string().await?;
 /// # Ok(()) }

--- a/src/request.rs
+++ b/src/request.rs
@@ -51,7 +51,7 @@ impl Request<NativeClient> {
     /// # Examples
     ///
     /// ```no_run
-    /// # #[runtime::main]
+    /// # #[async_std::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     /// use surf::{http, url};
     ///
@@ -97,7 +97,7 @@ impl<C: HttpClient> Request<C> {
     /// # Examples
     ///
     /// ```no_run
-    /// # #[runtime::main]
+    /// # #[async_std::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     /// let res = surf::get("https://httpbin.org/get")
     ///     .middleware(surf::middleware::logger::new())
@@ -115,7 +115,7 @@ impl<C: HttpClient> Request<C> {
     ///
     /// ```
     /// # use serde::{Deserialize, Serialize};
-    /// # #[runtime::main]
+    /// # #[async_std::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     /// #[derive(Serialize, Deserialize)]
     /// struct Index {
@@ -142,7 +142,7 @@ impl<C: HttpClient> Request<C> {
     ///
     /// ```
     /// # use serde::{Deserialize, Serialize};
-    /// # #[runtime::main]
+    /// # #[async_std::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     /// #[derive(Serialize, Deserialize)]
     /// struct Index {
@@ -174,7 +174,7 @@ impl<C: HttpClient> Request<C> {
     /// # Examples
     ///
     /// ```
-    /// # #[runtime::main]
+    /// # #[async_std::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     /// let req = surf::get("https://httpbin.org/get")
     ///     .set_header("X-Requested-With", "surf");
@@ -191,7 +191,7 @@ impl<C: HttpClient> Request<C> {
     /// # Examples
     ///
     /// ```
-    /// # #[runtime::main]
+    /// # #[async_std::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     /// let req = surf::get("https://httpbin.org/get")
     ///     .set_header("X-Requested-With", "surf");
@@ -210,7 +210,7 @@ impl<C: HttpClient> Request<C> {
     /// # Examples
     ///
     /// ```no_run
-    /// # #[runtime::main]
+    /// # #[async_std::main]
     /// # async fn main() -> Result<(), surf::Exception> {
     /// let mut req = surf::get("https://httpbin.org/get")
     ///     .set_header("X-Requested-With", "surf");
@@ -229,7 +229,7 @@ impl<C: HttpClient> Request<C> {
     /// # Examples
     ///
     /// ```
-    /// # #[runtime::main]
+    /// # #[async_std::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     /// use surf::http;
     /// let req = surf::get("https://httpbin.org/get");
@@ -246,7 +246,7 @@ impl<C: HttpClient> Request<C> {
     /// # Examples
     ///
     /// ```
-    /// # #[runtime::main]
+    /// # #[async_std::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     /// use surf::url::Url;
     /// let req = surf::get("https://httpbin.org/get");
@@ -273,7 +273,7 @@ impl<C: HttpClient> Request<C> {
     /// # Examples
     ///
     /// ```
-    /// # #[runtime::main]
+    /// # #[async_std::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     /// use surf::mime;
     /// let req = surf::post("https://httpbin.org/get")
@@ -293,7 +293,7 @@ impl<C: HttpClient> Request<C> {
     /// # Examples
     ///
     /// ```
-    /// # #[runtime::main]
+    /// # #[async_std::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     /// use surf::mime;
     /// let req = surf::post("https://httpbin.org/get")
@@ -314,7 +314,7 @@ impl<C: HttpClient> Request<C> {
     /// # Examples
     ///
     /// ```no_run
-    /// # #[runtime::main]
+    /// # #[async_std::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     /// let reader = surf::get("https://httpbin.org/get").await?;
     /// let uri = "https://httpbin.org/post";
@@ -343,7 +343,7 @@ impl<C: HttpClient> Request<C> {
     /// # Examples
     ///
     /// ```no_run
-    /// # #[runtime::main]
+    /// # #[async_std::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     /// let uri = "https://httpbin.org/post";
     /// let data = serde_json::json!({ "name": "chashu" });
@@ -365,7 +365,7 @@ impl<C: HttpClient> Request<C> {
     /// # Examples
     ///
     /// ```no_run
-    /// # #[runtime::main]
+    /// # #[async_std::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     /// let uri = "https://httpbin.org/post";
     /// let data = "hello world".to_string();
@@ -387,7 +387,7 @@ impl<C: HttpClient> Request<C> {
     /// # Examples
     ///
     /// ```no_run
-    /// # #[runtime::main]
+    /// # #[async_std::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     /// let uri = "https://httpbin.org/post";
     /// let data = b"hello world";
@@ -417,7 +417,7 @@ impl<C: HttpClient> Request<C> {
     /// # Examples
     ///
     /// ```no_run
-    /// # #[runtime::main]
+    /// # #[async_std::main]
     /// # async fn main() -> Result<(), surf::Exception> {
     /// let res = surf::post("https://httpbin.org/post")
     ///     .body_file("README.md")?
@@ -446,7 +446,7 @@ impl<C: HttpClient> Request<C> {
     ///
     /// ```
     /// # use serde::{Deserialize, Serialize};
-    /// # #[runtime::main]
+    /// # #[async_std::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     /// #[derive(Serialize, Deserialize)]
     /// struct Body {
@@ -474,7 +474,7 @@ impl<C: HttpClient> Request<C> {
     /// # Examples
     ///
     /// ```no_run
-    /// # #[runtime::main]
+    /// # #[async_std::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     /// let bytes = surf::get("https://httpbin.org/get").recv_bytes().await?;
     /// assert!(bytes.len() > 0);
@@ -490,7 +490,7 @@ impl<C: HttpClient> Request<C> {
     /// # Examples
     ///
     /// ```no_run
-    /// # #[runtime::main]
+    /// # #[async_std::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     /// let string = surf::get("https://httpbin.org/get").recv_string().await?;
     /// assert!(string.len() > 0);
@@ -507,7 +507,7 @@ impl<C: HttpClient> Request<C> {
     ///
     /// ```no_run
     /// # use serde::{Deserialize, Serialize};
-    /// # #[runtime::main]
+    /// # #[async_std::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     /// #[derive(Deserialize, Serialize)]
     /// struct Ip {
@@ -538,7 +538,7 @@ impl<C: HttpClient> Request<C> {
     ///
     /// ```no_run
     /// # use serde::{Deserialize, Serialize};
-    /// # #[runtime::main]
+    /// # #[async_std::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     /// #[derive(Deserialize, Serialize)]
     /// struct Body {

--- a/src/response.rs
+++ b/src/response.rs
@@ -29,7 +29,7 @@ impl Response {
     /// # Examples
     ///
     /// ```no_run
-    /// # #[runtime::main]
+    /// # #[async_std::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     /// let res = surf::get("https://httpbin.org/get").await?;
     /// assert_eq!(res.status(), 200);
@@ -44,7 +44,7 @@ impl Response {
     /// # Examples
     ///
     /// ```no_run
-    /// # #[runtime::main]
+    /// # #[async_std::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     /// use surf::http::version::Version;
     ///
@@ -61,7 +61,7 @@ impl Response {
     /// # Examples
     ///
     /// ```no_run
-    /// # #[runtime::main]
+    /// # #[async_std::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     /// let res = surf::get("https://httpbin.org/get").await?;
     /// assert!(res.header("Content-Length").is_some());
@@ -77,7 +77,7 @@ impl Response {
     /// # Examples
     ///
     /// ```no_run
-    /// # #[runtime::main]
+    /// # #[async_std::main]
     /// # async fn main() -> Result<(), surf::Exception> {
     /// let mut res = surf::post("https://httpbin.org/get").await?;
     /// for (name, value) in res.headers() {
@@ -102,7 +102,7 @@ impl Response {
     /// # Examples
     ///
     /// ```no_run
-    /// # #[runtime::main]
+    /// # #[async_std::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     /// use surf::mime;
     /// let res = surf::get("https://httpbin.org/json").await?;
@@ -127,7 +127,7 @@ impl Response {
     /// # Examples
     ///
     /// ```no_run
-    /// # #[runtime::main]
+    /// # #[async_std::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     /// let mut res = surf::get("https://httpbin.org/get").await?;
     /// let bytes: Vec<u8> = res.body_bytes().await?;
@@ -163,7 +163,7 @@ impl Response {
     /// # Examples
     ///
     /// ```no_run
-    /// # #[runtime::main]
+    /// # #[async_std::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     /// let mut res = surf::get("https://httpbin.org/get").await?;
     /// let string: String = res.body_string().await?;
@@ -193,7 +193,7 @@ impl Response {
     ///
     /// ```no_run
     /// # use serde::{Deserialize, Serialize};
-    /// # #[runtime::main]
+    /// # #[async_std::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     /// #[derive(Deserialize, Serialize)]
     /// struct Ip {
@@ -223,7 +223,7 @@ impl Response {
     ///
     /// ```no_run
     /// # use serde::{Deserialize, Serialize};
-    /// # #[runtime::main]
+    /// # #[async_std::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     /// #[derive(Deserialize, Serialize)]
     /// struct Body {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,4 +1,4 @@
-#[runtime::test]
+#[async_std::test]
 async fn post_json() -> Result<(), surf::Exception> {
     #[derive(serde::Deserialize, serde::Serialize)]
     struct Cat {
@@ -16,7 +16,7 @@ async fn post_json() -> Result<(), surf::Exception> {
     Ok(())
 }
 
-#[runtime::test]
+#[async_std::test]
 async fn get_json() -> Result<(), surf::Exception> {
     #[derive(serde::Deserialize)]
     struct Ip {


### PR DESCRIPTION
isahc 0.8.0 is out :tada: 

- Update futures-related dependencies to ones that use v0.3
- Use the #[main] and #[test] attributes from async-std instead of from runtime
- Add missing dependencies to the `hyper-client` feature

I didn't update hyper to the alpha that uses futures 0.3 yet. That could be a later PR.

There is still an issue with the hyper implementation, it doesn't compile. This is also true on the main branch right now. I started porting it to async-std, which helped a bit, but it seems there's no way to actually use the HyperClient anyway right now and designing a way to access it seems out of scope for this PR. I guess the http_client module is moving into its own crate anyways?

Fixes #100