### PR TITLE
Fix README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
         let mut res = surf::get("https://httpbin.org/get").await?;
         dbg!(res.body_string().await?);
         Ok(())
-    });
+    })
 }
 ```
 
@@ -83,7 +83,7 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     task::block_on(async {
         dbg!(surf::get("https://httpbin.org/get").recv_string().await?);
         Ok(())
-    });
+    })
 }
 ```
 
@@ -123,7 +123,7 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
         let reader = surf::get("https://img.fyi/q6YvNqP").await?;
         let res = surf::post("https://box.rs/upload").body(reader).await?;
         Ok(())
-    });
+    })
 }
 ```
 


### PR DESCRIPTION
Previously, the task::block_on calls in the readme examples were followed by semicolons, which makes Rust ignore them as implicit return types. This removes the semicolons, fixing the return types.