### PR TITLE
Export NativeClient

### DIFF
--- a/src/http_client/native.rs
+++ b/src/http_client/native.rs
@@ -1,5 +1,5 @@
 #[cfg(all(feature = "curl-client", not(target_arch = "wasm32")))]
-pub(crate) use super::isahc::IsahcClient as NativeClient;
+pub use super::isahc::IsahcClient as NativeClient;
 
 #[cfg(all(feature = "wasm-client", target_arch = "wasm32"))]
-pub(crate) use super::wasm::WasmClient as NativeClient;
+pub use super::wasm::WasmClient as NativeClient;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,6 +87,7 @@ pub use mime;
 pub use url;
 
 pub use client::Client;
+pub use http_client::native::NativeClient;
 pub use request::Request;
 pub use response::{DecodeError, Response};
 


### PR DESCRIPTION
It could be better if we export `NativeClient`, that way we could create custom wrappers for `surf::Client`