### PR TITLE
Remove unnecessary to_owned() calls.

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -69,7 +69,7 @@ impl<C: HttpClient> Client<C> {
     /// # Ok(()) }
     /// ```
     pub fn get(&self, uri: impl AsRef<str>) -> Request<C> {
-        let uri = uri.as_ref().to_owned().parse().unwrap();
+        let uri = uri.as_ref().parse().unwrap();
         Request::with_client(http::Method::GET, uri, self.client.clone())
     }
 
@@ -93,7 +93,7 @@ impl<C: HttpClient> Client<C> {
     /// # Ok(()) }
     /// ```
     pub fn head(&self, uri: impl AsRef<str>) -> Request<C> {
-        let uri = uri.as_ref().to_owned().parse().unwrap();
+        let uri = uri.as_ref().parse().unwrap();
         Request::with_client(http::Method::HEAD, uri, self.client.clone())
     }
 
@@ -117,7 +117,7 @@ impl<C: HttpClient> Client<C> {
     /// # Ok(()) }
     /// ```
     pub fn post(&self, uri: impl AsRef<str>) -> Request<C> {
-        let uri = uri.as_ref().to_owned().parse().unwrap();
+        let uri = uri.as_ref().parse().unwrap();
         Request::with_client(http::Method::POST, uri, self.client.clone())
     }
 
@@ -141,7 +141,7 @@ impl<C: HttpClient> Client<C> {
     /// # Ok(()) }
     /// ```
     pub fn put(&self, uri: impl AsRef<str>) -> Request<C> {
-        let uri = uri.as_ref().to_owned().parse().unwrap();
+        let uri = uri.as_ref().parse().unwrap();
         Request::with_client(http::Method::PUT, uri, self.client.clone())
     }
 
@@ -165,7 +165,7 @@ impl<C: HttpClient> Client<C> {
     /// # Ok(()) }
     /// ```
     pub fn delete(&self, uri: impl AsRef<str>) -> Request<C> {
-        let uri = uri.as_ref().to_owned().parse().unwrap();
+        let uri = uri.as_ref().parse().unwrap();
         Request::with_client(http::Method::DELETE, uri, self.client.clone())
     }
 
@@ -189,7 +189,7 @@ impl<C: HttpClient> Client<C> {
     /// # Ok(()) }
     /// ```
     pub fn connect(&self, uri: impl AsRef<str>) -> Request<C> {
-        let uri = uri.as_ref().to_owned().parse().unwrap();
+        let uri = uri.as_ref().parse().unwrap();
         Request::with_client(http::Method::CONNECT, uri, self.client.clone())
     }
 
@@ -213,7 +213,7 @@ impl<C: HttpClient> Client<C> {
     /// # Ok(()) }
     /// ```
     pub fn options(&self, uri: impl AsRef<str>) -> Request<C> {
-        let uri = uri.as_ref().to_owned().parse().unwrap();
+        let uri = uri.as_ref().parse().unwrap();
         Request::with_client(http::Method::OPTIONS, uri, self.client.clone())
     }
 
@@ -237,7 +237,7 @@ impl<C: HttpClient> Client<C> {
     /// # Ok(()) }
     /// ```
     pub fn trace(&self, uri: impl AsRef<str>) -> Request<C> {
-        let uri = uri.as_ref().to_owned().parse().unwrap();
+        let uri = uri.as_ref().parse().unwrap();
         Request::with_client(http::Method::TRACE, uri, self.client.clone())
     }
 
@@ -261,7 +261,7 @@ impl<C: HttpClient> Client<C> {
     /// # Ok(()) }
     /// ```
     pub fn patch(&self, uri: impl AsRef<str>) -> Request<C> {
-        let uri = uri.as_ref().to_owned().parse().unwrap();
+        let uri = uri.as_ref().parse().unwrap();
         Request::with_client(http::Method::PATCH, uri, self.client.clone())
     }
 }

--- a/src/headers.rs
+++ b/src/headers.rs
@@ -21,7 +21,7 @@ impl<'a> Headers<'a> {
 
     /// Set a header.
     pub fn insert(&mut self, key: &'static str, value: impl AsRef<str>) -> Option<String> {
-        let value = value.as_ref().to_owned();
+        let value = value.as_ref();
         let res = self.headers.insert(key, value.parse().unwrap());
         res.as_ref().map(|h| h.to_str().unwrap().to_owned())
     }

--- a/src/one_off.rs
+++ b/src/one_off.rs
@@ -31,7 +31,7 @@ use super::Request;
 /// # Ok(()) }
 /// ```
 pub fn get(uri: impl AsRef<str>) -> Request<NativeClient> {
-    let uri = uri.as_ref().to_owned().parse().unwrap();
+    let uri = uri.as_ref().parse().unwrap();
     Request::new(http::Method::GET, uri)
 }
 
@@ -72,7 +72,7 @@ pub fn get(uri: impl AsRef<str>) -> Request<NativeClient> {
 /// # Ok(()) }
 /// ```
 pub fn head(uri: impl AsRef<str>) -> Request<NativeClient> {
-    let uri = uri.as_ref().to_owned().parse().unwrap();
+    let uri = uri.as_ref().parse().unwrap();
     Request::new(http::Method::HEAD, uri)
 }
 
@@ -130,7 +130,7 @@ pub fn head(uri: impl AsRef<str>) -> Request<NativeClient> {
 /// # Ok(()) }
 /// ```
 pub fn post(uri: impl AsRef<str>) -> Request<NativeClient> {
-    let uri = uri.as_ref().to_owned().parse().unwrap();
+    let uri = uri.as_ref().parse().unwrap();
     Request::new(http::Method::POST, uri)
 }
 
@@ -166,7 +166,7 @@ pub fn post(uri: impl AsRef<str>) -> Request<NativeClient> {
 /// # Ok(()) }
 /// ```
 pub fn put(uri: impl AsRef<str>) -> Request<NativeClient> {
-    let uri = uri.as_ref().to_owned().parse().unwrap();
+    let uri = uri.as_ref().parse().unwrap();
     Request::new(http::Method::PUT, uri)
 }
 
@@ -197,7 +197,7 @@ pub fn put(uri: impl AsRef<str>) -> Request<NativeClient> {
 /// # Ok(()) }
 /// ```
 pub fn delete(uri: impl AsRef<str>) -> Request<NativeClient> {
-    let uri = uri.as_ref().to_owned().parse().unwrap();
+    let uri = uri.as_ref().parse().unwrap();
     Request::new(http::Method::DELETE, uri)
 }
 
@@ -237,7 +237,7 @@ pub fn delete(uri: impl AsRef<str>) -> Request<NativeClient> {
 /// # Ok(()) }
 /// ```
 pub fn connect(uri: impl AsRef<str>) -> Request<NativeClient> {
-    let uri = uri.as_ref().to_owned().parse().unwrap();
+    let uri = uri.as_ref().parse().unwrap();
     Request::new(http::Method::CONNECT, uri)
 }
 
@@ -270,7 +270,7 @@ pub fn connect(uri: impl AsRef<str>) -> Request<NativeClient> {
 /// # Ok(()) }
 /// ```
 pub fn options(uri: impl AsRef<str>) -> Request<NativeClient> {
-    let uri = uri.as_ref().to_owned().parse().unwrap();
+    let uri = uri.as_ref().parse().unwrap();
     Request::new(http::Method::OPTIONS, uri)
 }
 
@@ -307,7 +307,7 @@ pub fn options(uri: impl AsRef<str>) -> Request<NativeClient> {
 /// # Ok(()) }
 /// ```
 pub fn trace(uri: impl AsRef<str>) -> Request<NativeClient> {
-    let uri = uri.as_ref().to_owned().parse().unwrap();
+    let uri = uri.as_ref().parse().unwrap();
     Request::new(http::Method::TRACE, uri)
 }
 
@@ -350,6 +350,6 @@ pub fn trace(uri: impl AsRef<str>) -> Request<NativeClient> {
 /// # Ok(()) }
 /// ```
 pub fn patch(uri: impl AsRef<str>) -> Request<NativeClient> {
-    let uri = uri.as_ref().to_owned().parse().unwrap();
+    let uri = uri.as_ref().parse().unwrap();
     Request::new(http::Method::PATCH, uri)
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -199,7 +199,7 @@ impl<C: HttpClient> Request<C> {
     /// # Ok(()) }
     /// ```
     pub fn set_header(mut self, key: &'static str, value: impl AsRef<str>) -> Self {
-        let value = value.as_ref().to_owned();
+        let value = value.as_ref();
         let req = self.req.as_mut().unwrap();
         req.headers_mut().insert(key, value.parse().unwrap());
         self


### PR DESCRIPTION
`parse()` is a method on `&str`, so these things don't need to first be
converted to a `String`.