### PR TITLE
Fix `fmt`/`doc` CI job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,20 +46,13 @@ jobs:
     steps:
     - uses: actions/checkout@master
 
-    - id: component
-      uses: actions-rs/components-nightly@v1
+    - name: Install stable toolchain
+      uses: actions-rs/toolchain@v1
       with:
-        component: rustfmt
-
-    - uses: actions-rs/toolchain@v1
-      with:
-          toolchain: ${{ steps.component.outputs.toolchain }}
-          override: true
-
-    - name: setup
-      run: |
-        rustup component add rustfmt
-        rustc --version
+        profile: minimal
+        toolchain: stable
+        override: true
+        components: rustfmt
 
     - name: fmt
       run: cargo fmt --all -- --check


### PR DESCRIPTION
Use the `stable` toolchain for fmt checks. I guess it was using nightly in the past because of async/await, but that's no longer needed \o/