### PR TITLE
Making set_header more flexible for native client

### DIFF
--- a/src/headers.rs
+++ b/src/headers.rs
@@ -15,12 +15,18 @@ impl<'a> Headers<'a> {
     }
 
     /// Get a header.
-    pub fn get(&self, key: &'static str) -> Option<&'_ str> {
+    pub fn get<K>(&self, key: K) -> Option<&'_ str>
+    where
+        K: http::header::AsHeaderName,
+    {
         self.headers.get(key).map(|h| h.to_str().unwrap())
     }
 
     /// Set a header.
-    pub fn insert(&mut self, key: &'static str, value: impl AsRef<str>) -> Option<String> {
+    pub fn insert<K>(&mut self, key: K, value: impl AsRef<str>) -> Option<String>
+    where
+        K: http::header::IntoHeaderName,
+    {
         let value = value.as_ref().to_owned();
         let res = self.headers.insert(key, value.parse().unwrap());
         res.as_ref().map(|h| h.to_str().unwrap().to_owned())

--- a/src/request.rs
+++ b/src/request.rs
@@ -198,7 +198,10 @@ impl<C: HttpClient> Request<C> {
     /// assert_eq!(req.header("X-Requested-With"), Some("surf"));
     /// # Ok(()) }
     /// ```
-    pub fn set_header(mut self, key: &'static str, value: impl AsRef<str>) -> Self {
+    pub fn set_header<K>(mut self, key: K, value: impl AsRef<str>) -> Self
+    where
+        K: http::header::IntoHeaderName,
+    {
         let value = value.as_ref().to_owned();
         let req = self.req.as_mut().unwrap();
         req.headers_mut().insert(key, value.parse().unwrap());

--- a/src/request.rs
+++ b/src/request.rs
@@ -181,7 +181,10 @@ impl<C: HttpClient> Request<C> {
     /// assert_eq!(req.header("X-Requested-With"), Some("surf"));
     /// # Ok(()) }
     /// ```
-    pub fn header(&self, key: &'static str) -> Option<&'_ str> {
+    pub fn header<K>(&self, key: K) -> Option<&'_ str> 
+    where
+        K: http::header::AsHeaderName,
+    {
         let req = self.req.as_ref().unwrap();
         req.headers().get(key).map(|h| h.to_str().unwrap())
     }


### PR DESCRIPTION
This enables the set_header method to be used with every type that can be convert into a header name instead of just &'static str. It works for native_client use cases.