### PR TITLE
Add unstable feature and export NativeClient with it

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ hyper-client = ["hyper", "hyper-tls", "native-tls", "runtime", "runtime-raw", "r
 curl-client = ["isahc"]
 wasm-client = ["js-sys", "web-sys", "wasm-bindgen", "wasm-bindgen-futures"]
 middleware-logger = []
+unstable = []
 encoding = ["encoding_rs"]
 
 [dependencies]

--- a/src/http_client/native.rs
+++ b/src/http_client/native.rs
@@ -1,3 +1,10 @@
+#[cfg(all(
+    feature = "curl-client",
+    feature = "unstable",
+    not(target_arch = "wasm32")
+))]
+pub use super::isahc::IsahcClient as NativeClient;
+
 #[cfg(all(feature = "curl-client", not(target_arch = "wasm32")))]
 pub(crate) use super::isahc::IsahcClient as NativeClient;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,6 +90,9 @@ pub use client::Client;
 pub use request::Request;
 pub use response::{DecodeError, Response};
 
+#[cfg(all(feature = "unstable", feature = "native-client"))]
+pub use http_client::native::NativeClient;
+
 #[cfg(feature = "native-client")]
 mod one_off;
 #[cfg(feature = "native-client")]


### PR DESCRIPTION
Resolves #96 

Hello, I want to be able to wrap the surf client struct in another struct in a project I'm working on. Currently this type is not exposed because of stability guarentees. This PR adds a `unstable` feature flag and exports the `NativeClient` type with this feature enabled. This gives users a way to opt in to being able to reference the type, without requiring semver compatibility.