### PR TITLE
Set Content-Length if we can

### DIFF
--- a/src/http_client/isahc.rs
+++ b/src/http_client/isahc.rs
@@ -40,7 +40,10 @@ impl HttpClient for IsahcClient {
         let client = self.client.clone();
         Box::pin(async move {
             let (parts, body) = req.into_parts();
-            let body = isahc::Body::reader(body);
+            let body = match body.len {
+                Some(len) => isahc::Body::reader_sized(body, len),
+                None => isahc::Body::reader(body),
+            };
             let req: http::Request<isahc::Body> = http::Request::from_parts(parts, body);
 
             let res = client.send_async(req).await?;


### PR DESCRIPTION
Hi!

This PR adds tracking of body's size, which should allow the client to set `Content-Length` properly. The actual plumbing is only implemented for `isahc` client. 

This PR interacts with https://github.com/http-rs/surf/pull/124, which moves the relevant code to another repository. It's probably best to merge 124 first, and then re-apply this diff onto `surf/http-client` repo!