### PR TITLE
set up an msrv in ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        rust: [nightly]
+        rust: ["1.39.0", nightly]
 
     steps:
     - uses: actions/checkout@master


### PR DESCRIPTION
Not intending to make this particularly official, but considering a lot of users are probably running surf on 1.39.0, it might be nice to have CI test against that along with nightly.