### PR TITLE
Fix errors when compiling for wasm

### DIFF
--- a/src/middleware/logger/wasm.rs
+++ b/src/middleware/logger/wasm.rs
@@ -1,5 +1,5 @@
-use http_client::HttpClient;
 use crate::middleware::{Middleware, Next, Request, Response};
+use http_client::HttpClient;
 
 use futures::future::BoxFuture;
 

--- a/src/middleware/logger/wasm.rs
+++ b/src/middleware/logger/wasm.rs
@@ -1,4 +1,4 @@
-use crate::http_client::HttpClient;
+use http_client::HttpClient;
 use crate::middleware::{Middleware, Next, Request, Response};
 
 use futures::future::BoxFuture;

--- a/src/response.rs
+++ b/src/response.rs
@@ -387,7 +387,7 @@ fn decode_body(mut bytes: Vec<u8>, content_encoding: Option<&str>) -> Result<Str
 
     // Encoding names are always valid ASCII, so we can avoid including casing mapping tables
     let content_encoding = content_encoding.unwrap_or("utf-8").to_ascii_lowercase();
-    if is_utf8_encoding(content_encoding) {
+    if is_utf8_encoding(&content_encoding) {
         return String::from_utf8(bytes)
             .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err).into());
     }


### PR DESCRIPTION
There are currently a small number of compile errors when compiling `surf` with the default features for wasm. The initial commit fixes most of them, however there is still an error because of a bug in `http_client` that will have to wait for https://github.com/http-rs/http-client/pull/16.