### PR TITLE
Add close paren to readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
         let Ip { ip } = surf::get(uri).recv_json().await?;
         assert!(ip.len() > 10);
         Ok(())
-    }
+    })
 }
 ```
 


### PR DESCRIPTION
A very tiny PR! 🙈 

I was trying out the library by just copying and pasting the examples and noticed this one was missing a closing paren at the end. Thought I'd help a little bit!

Cheers for working on the crate, it's very cool 😎 