### PR TITLE
Remove default dependency on native-client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,32 +12,51 @@ readme = "README.md"
 edition = "2018"
 
 [features]
-default = ["native-client", "middleware-logger", "encoding"]
-native-client = ["curl-client", "wasm-client"]
+default = ["middleware-logger", "encoding"]
+native-client = ["http-client/native_client", "curl-client", "wasm-client"]
 hyper-client = ["hyper", "hyper-tls", "native-tls", "runtime", "runtime-raw", "runtime-tokio" ]
-curl-client = ["isahc"]
-wasm-client = ["js-sys", "web-sys", "wasm-bindgen", "wasm-bindgen-futures"]
-middleware-logger = []
+curl-client = ["http-client/curl_client"]
+wasm-client = ["http-client/wasm_client"]
+middleware-logger = ["log"]
 encoding = ["encoding_rs"]
+
+[[example]]
+name = "hello_world"
+required-features = ["native-client"]
+
+[[example]]
+name = "middleware"
+required-features = ["native-client"]
+
+[[example]]
+name = "next_reuse"
+required-features = ["native-client"]
+
+[[example]]
+name = "persistent"
+required-features = ["native-client"]
+
+[[example]]
+name = "post"
+required-features = ["native-client"]
 
 [dependencies]
 futures = { version = "0.3.1", features = ["compat", "io-compat"] }
 http = "0.1.17"
-log = { version = "0.4.7", features = ["kv_unstable"] }
 mime = "0.3.13"
 mime_guess = "2.0.0-alpha.6"
 serde = "1.0.97"
 serde_json = "1.0.40"
 serde_urlencoded = "0.6.1"
 url = "2.0.0"
-http-client = { version = "1.1.0", features = ["native_client"] }
+http-client = { version = "1.1.0" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 # encoding
 encoding_rs = { version = "0.8.20", optional = true }
 
-# isahc-client
-isahc = { version = "0.8", optional = true, default-features = false, features = ["http2"]  }
+# middleware-logger
+log = { version = "0.4.7", optional = true, features = ["kv_unstable"] }
 
 # hyper-client
 hyper = { version = "0.12.32", optional = true, default-features = false }
@@ -46,12 +65,6 @@ native-tls = { version = "0.2.2", optional = true }
 runtime = { version = "0.3.0-alpha.6", optional = true }
 runtime-raw = { version = "0.3.0-alpha.4", optional = true }
 runtime-tokio = { version = "0.3.0-alpha.5", optional = true }
-
-# wasm-client
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-js-sys = { version = "0.3.25", optional = true }
-wasm-bindgen = { version = "0.2.48", optional = true }
-wasm-bindgen-futures = { version = "0.4.5", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.web-sys]
 version = "0.3.25"

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -49,6 +49,7 @@
 #[doc(inline)]
 pub use http_client::{Body, HttpClient, Request, Response};
 
+#[cfg(feature = "middleware-logger")]
 pub mod logger;
 
 use crate::Exception;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "native-client")]
+
 use mockito::mock;
 
 #[async_std::test]


### PR DESCRIPTION
As a side effect, this allows surf to compile without default features.

NOTE: the above is not currently true because doctests depend on
native-client and middleware-logger. Any suggestions on how to plumb a
feature requirement into doctests?