### PR TITLE
test: upgrade mockito

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,4 +76,4 @@ features = [
 async-std = { version = "1.0", features = ["attributes"] }
 femme = "1.1.0"
 serde = { version = "1.0.97", features = ["derive"] }
-mockito = "0.22.0"
+mockito = "0.23.0"


### PR DESCRIPTION
Semver bump is because of new msrv, which we don't care about.

The previous version of `mockito` fails to compile for me:

```
   Compiling mockito v0.22.0
error[E0432]: unresolved imports `assert_json_diff::Comparison`, `assert_json_diff::Actual`, `assert_json_diff::Expected`
   --> /home/faux/.cargo/registry/src/github.com-1ecc6299db9ec823/mockito-0.22.0/src/lib.rs:527:24
    |
527 | use assert_json_diff::{Comparison, assert_json_no_panic, Actual, Expected};
    |                        ^^^^^^^^^^                        ^^^^^^  ^^^^^^^^ no `Expected` in the root
    |                        |                                 |
    |                        |                                 no `Actual` in the root
    |                        no `Comparison` in the root

error[E0603]: function `assert_json_no_panic` is private
   --> /home/faux/.cargo/registry/src/github.com-1ecc6299db9ec823/mockito-0.22.0/src/lib.rs:527:36
    |
527 | use assert_json_diff::{Comparison, assert_json_no_panic, Actual, Expected};
    |                                    ^^^^^^^^^^^^^^^^^^^^ this function is private
    |
note: the function `assert_json_no_panic` is defined here
   --> /home/faux/.cargo/registry/src/github.com-1ecc6299db9ec823/assert-json-diff-1.0.3/src/lib.rs:241:1
    |
241 | fn assert_json_no_panic(lhs: &Value, rhs: &Value, mode: Mode) -> Result<(), String> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: aborting due to 2 previous errors
```