### PR TITLE
Update mime_guess requirement.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ futures = { version = "0.3.1", features = ["compat", "io-compat"] }
 http = "0.1.17"
 log = { version = "0.4.7", features = ["kv_unstable"] }
 mime = "0.3.13"
-mime_guess = "2.0.0-alpha.6"
+mime_guess = "2.0.3"
 serde = "1.0.97"
 serde_json = "1.0.40"
 serde_urlencoded = "0.6.1"


### PR DESCRIPTION
The `alpha.6` release doesn't actually have the `from_path` method that we use yet.