### PR TITLE
Add optional simd-json support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ serde_json = "1.0.40"
 serde_urlencoded = "0.6.1"
 url = "2.0.0"
 http-client = { version = "1.1.0", features = ["native_client"] }
-simd-json = { version = "0.3.2", optional = true }
+simd-json = { version = "0.3.7", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 # encoding

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ serde_json = "1.0.40"
 serde_urlencoded = "0.6.1"
 url = "2.0.0"
 http-client = { version = "1.1.0", features = ["native_client"] }
+simd-json = { version = "0.3.2", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 # encoding

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,7 @@
 //! - __`curl-client`:__ use `curl` (through `isahc`) as the HTTP backend.
 //! - __`hyper-client`:__ use `hyper` as the HTTP backend.
 //! - __`wasm-client`:__ use `window.fetch` as the HTTP backend.
+//! - __`simd-json`:__ uses simd-json instead of serde for json parsing. Note: you got to pass `-C target-feature=+avx,+avx2,+sse4.2` to `RUSTFLAGS` if this is enabled.
 
 #![forbid(future_incompatible, rust_2018_idioms)]
 #![deny(missing_debug_implementations, nonstandard_style)]

--- a/src/request.rs
+++ b/src/request.rs
@@ -358,7 +358,15 @@ impl<C: HttpClient> Request<C> {
     /// # Ok(()) }
     /// ```
     pub fn body_json(mut self, json: &(impl Serialize + ?Sized)) -> serde_json::Result<Self> {
-        *self.req.as_mut().unwrap().body_mut() = serde_json::to_vec(json)?.into();
+        #[cfg(not(feature = "simd-json"))]
+        {
+            *self.req.as_mut().unwrap().body_mut() = serde_json::to_vec(json)?.into();
+        }
+        #[cfg(feature = "simd-json")]
+        {
+            *self.req.as_mut().unwrap().body_mut() = simd_json::to_vec(json)?.into();
+        }
+
         Ok(self.set_mime(mime::APPLICATION_JSON))
     }
 


### PR DESCRIPTION
This adds the `simd-json` as a feature flag to use SIMD accelerated JSON parsing.

This might warrant a note in the README about cpu features required (AVX2 or SSE4.1) to use the flag but I didn't find a section in the README on features and wasn't sure if you want one added so I'll just open this for suggestions :).