### PR TITLE
Switch to a concrete Error type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ http = "0.1.17"
 log = { version = "0.4.7", features = ["kv_unstable"] }
 mime = "0.3.13"
 mime_guess = "2.0.3"
+thiserror = "1.0"
 serde = "1.0.97"
 serde_json = "1.0.40"
 serde_urlencoded = "0.6.1"
@@ -73,6 +74,7 @@ features = [
 ]
 
 [dev-dependencies]
+anyhow = "1.0"
 async-std = { version = "1.0", features = ["attributes"] }
 femme = "1.1.0"
 serde = { version = "1.0.97", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ quick script, or a cross-platform SDK, Surf will make it work.
 ```rust
 use async_std::task;
 
-fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+fn main() -> Result<(), surf::Error> {
     task::block_on(async {
         let mut res = surf::get("https://httpbin.org/get").await?;
         dbg!(res.body_string().await?);
@@ -79,7 +79,7 @@ type directly.
 ```rust
 use async_std::task;
 
-fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+fn main() -> Result<(), surf::Error> {
     task::block_on(async {
         dbg!(surf::get("https://httpbin.org/get").recv_string().await?);
         Ok(())
@@ -93,7 +93,7 @@ Both sending and receiving JSON is real easy too.
 use async_std::task;
 use serde::{Deserialize, Serialize};
 
-fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+fn main() -> Result<(), surf::Error> {
     #[derive(Deserialize, Serialize)]
     struct Ip {
         ip: String
@@ -118,7 +118,7 @@ And even creating streaming proxies is no trouble at all.
 ```rust
 use async_std::task;
 
-fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+fn main() -> Result<(), surf::Error> {
     task::block_on(async {
         let reader = surf::get("https://img.fyi/q6YvNqP").await?;
         let res = surf::post("https://box.rs/upload").body(reader).await?;
@@ -129,11 +129,11 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
 
 ## Installation
 
-Install OpenSSL - 
+Install OpenSSL -
 - Ubuntu - ``` sudo apt install libssl-dev ```
 - Fedora - ``` sudo dnf install openssl-devel ```
 
-Make sure your rust is up to date using: 
+Make sure your rust is up to date using:
 ``` rustup update ```
 
 With [cargo add](https://github.com/killercup/cargo-edit#Installation) installed :

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -2,13 +2,13 @@ use async_std::task;
 
 // The need for Ok with turbofish is explained here
 // https://rust-lang.github.io/async-book/07_workarounds/03_err_in_async_blocks.html
-fn main() -> Result<(), surf::Exception> {
+fn main() -> anyhow::Result<()> {
     femme::start(log::LevelFilter::Info)?;
 
     task::block_on(async {
         let uri = "https://httpbin.org/get";
         let string: String = surf::get(uri).recv_string().await?;
         println!("{}", string);
-        Ok::<(), surf::Exception>(())
+        Ok(())
     })
 }

--- a/examples/next_reuse.rs
+++ b/examples/next_reuse.rs
@@ -2,6 +2,7 @@ use async_std::task;
 use futures::future::BoxFuture;
 use futures::io::AsyncReadExt;
 use surf::middleware::{Body, HttpClient, Middleware, Next, Request, Response};
+use surf::Result;
 
 struct Doubler;
 
@@ -11,7 +12,7 @@ impl<C: HttpClient> Middleware<C> for Doubler {
         req: Request,
         client: C,
         next: Next<'a, C>,
-    ) -> BoxFuture<'a, Result<Response, surf::Exception>> {
+    ) -> BoxFuture<'a, Result<Response>> {
         if req.method().is_safe() {
             let mut new_req = Request::new(Body::empty());
             *new_req.method_mut() = req.method().clone();
@@ -43,7 +44,7 @@ impl<C: HttpClient> Middleware<C> for Doubler {
 
 // The need for Ok with turbofish is explained here
 // https://rust-lang.github.io/async-book/07_workarounds/03_err_in_async_blocks.html
-fn main() -> Result<(), surf::Exception> {
+fn main() -> surf::Result<()> {
     femme::start(log::LevelFilter::Info).unwrap();
     task::block_on(async {
         let mut res = surf::get("https://httpbin.org/get")
@@ -53,6 +54,6 @@ fn main() -> Result<(), surf::Exception> {
         let body = res.body_bytes().await?;
         let body = String::from_utf8_lossy(&body);
         println!("{}", body);
-        Ok::<(), surf::Exception>(())
+        Ok(())
     })
 }

--- a/examples/persistent.rs
+++ b/examples/persistent.rs
@@ -2,13 +2,13 @@ use async_std::task;
 
 // The need for Ok with turbofish is explained here
 // https://rust-lang.github.io/async-book/07_workarounds/03_err_in_async_blocks.html
-fn main() -> Result<(), surf::Exception> {
+fn main() -> surf::Result<()> {
     femme::start(log::LevelFilter::Info).unwrap();
     task::block_on(async {
         let client = surf::Client::new();
         let req1 = client.get("https://httpbin.org/get").recv_string();
         let req2 = client.get("https://httpbin.org/get").recv_string();
         futures::future::try_join(req1, req2).await?;
-        Ok::<(), surf::Exception>(())
+        Ok(())
     })
 }

--- a/examples/post.rs
+++ b/examples/post.rs
@@ -2,13 +2,13 @@ use async_std::task;
 
 // The need for Ok with turbofish is explained here
 // https://rust-lang.github.io/async-book/07_workarounds/03_err_in_async_blocks.html
-fn main() -> Result<(), surf::Exception> {
+fn main() -> surf::Result<()> {
     femme::start(log::LevelFilter::Info).unwrap();
     task::block_on(async {
         let uri = "https://httpbin.org/post";
         let data = serde_json::json!({ "name": "chashu" });
         let res = surf::post(uri).body_json(&data).unwrap().await?;
         assert_eq!(res.status(), 200);
-        Ok::<(), surf::Exception>(())
+        Ok(())
     })
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -10,7 +10,7 @@ use http_client::native::NativeClient;
 ///
 /// ```no_run
 /// # #[async_std::main]
-/// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+/// # async fn main() -> Result<(), surf::Error> {
 /// let client = surf::Client::new();
 /// let req1 = client.get("https://httpbin.org/get").recv_string();
 /// let req2 = client.get("https://httpbin.org/get").recv_string();
@@ -30,7 +30,7 @@ impl Client<NativeClient> {
     ///
     /// ```no_run
     /// # #[async_std::main]
-    /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+    /// # async fn main() -> Result<(), surf::Error> {
     /// let client = surf::Client::new();
     /// # Ok(()) }
     /// ```
@@ -63,7 +63,7 @@ impl<C: HttpClient> Client<C> {
     ///
     /// ```no_run
     /// # #[async_std::main]
-    /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+    /// # async fn main() -> Result<(), surf::Error> {
     /// let client = surf::Client::new();
     /// let string = client.get("https://httpbin.org/get").recv_string().await?;
     /// # Ok(()) }
@@ -87,7 +87,7 @@ impl<C: HttpClient> Client<C> {
     ///
     /// ```no_run
     /// # #[async_std::main]
-    /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+    /// # async fn main() -> Result<(), surf::Error> {
     /// let client = surf::Client::new();
     /// let string = client.head("https://httpbin.org/head").recv_string().await?;
     /// # Ok(()) }
@@ -111,7 +111,7 @@ impl<C: HttpClient> Client<C> {
     ///
     /// ```no_run
     /// # #[async_std::main]
-    /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+    /// # async fn main() -> Result<(), surf::Error> {
     /// let client = surf::Client::new();
     /// let string = client.post("https://httpbin.org/post").recv_string().await?;
     /// # Ok(()) }
@@ -135,7 +135,7 @@ impl<C: HttpClient> Client<C> {
     ///
     /// ```no_run
     /// # #[async_std::main]
-    /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+    /// # async fn main() -> Result<(), surf::Error> {
     /// let client = surf::Client::new();
     /// let string = client.put("https://httpbin.org/put").recv_string().await?;
     /// # Ok(()) }
@@ -159,7 +159,7 @@ impl<C: HttpClient> Client<C> {
     ///
     /// ```no_run
     /// # #[async_std::main]
-    /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+    /// # async fn main() -> Result<(), surf::Error> {
     /// let client = surf::Client::new();
     /// let string = client.delete("https://httpbin.org/delete").recv_string().await?;
     /// # Ok(()) }
@@ -183,7 +183,7 @@ impl<C: HttpClient> Client<C> {
     ///
     /// ```no_run
     /// # #[async_std::main]
-    /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+    /// # async fn main() -> Result<(), surf::Error> {
     /// let client = surf::Client::new();
     /// let string = client.connect("https://httpbin.org/connect").recv_string().await?;
     /// # Ok(()) }
@@ -207,7 +207,7 @@ impl<C: HttpClient> Client<C> {
     ///
     /// ```no_run
     /// # #[async_std::main]
-    /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+    /// # async fn main() -> Result<(), surf::Error> {
     /// let client = surf::Client::new();
     /// let string = client.options("https://httpbin.org/options").recv_string().await?;
     /// # Ok(()) }
@@ -231,7 +231,7 @@ impl<C: HttpClient> Client<C> {
     ///
     /// ```no_run
     /// # #[async_std::main]
-    /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+    /// # async fn main() -> Result<(), surf::Error> {
     /// let client = surf::Client::new();
     /// let string = client.trace("https://httpbin.org/trace").recv_string().await?;
     /// # Ok(()) }
@@ -255,7 +255,7 @@ impl<C: HttpClient> Client<C> {
     ///
     /// ```no_run
     /// # #[async_std::main]
-    /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+    /// # async fn main() -> Result<(), surf::Error> {
     /// let client = surf::Client::new();
     /// let string = client.patch("https://httpbin.org/patch").recv_string().await?;
     /// # Ok(()) }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,43 @@
+use std::result::Result as StdResult;
+
+use thiserror::Error as ThisError;
+
+#[allow(missing_docs)]
+pub type Result<T> = StdResult<T, Error>;
+
+#[allow(missing_docs)]
+#[derive(ThisError, Debug)]
+#[error(transparent)]
+pub struct Error(#[from] InternalError);
+
+macro_rules! impl_from {
+    ($bound:ty) => {
+        impl From<$bound> for Error {
+            fn from(err: $bound) -> Error {
+                InternalError::from(err).into()
+            }
+        }
+    };
+}
+
+impl_from!(log::kv::Error);
+impl_from!(serde_urlencoded::ser::Error);
+impl_from!(serde_urlencoded::de::Error);
+impl_from!(std::io::Error);
+impl_from!(serde_json::Error);
+
+#[derive(ThisError, Debug)]
+pub(crate) enum InternalError {
+    #[error(transparent)]
+    LogError(#[from] log::kv::Error),
+    #[error(transparent)]
+    UrlEncodeError(#[from] serde_urlencoded::ser::Error),
+    #[error(transparent)]
+    UrlDecodeError(#[from] serde_urlencoded::de::Error),
+    #[error(transparent)]
+    IoError(#[from] std::io::Error),
+    #[error(transparent)]
+    JsonError(#[from] serde_json::Error),
+    #[error("{0}")]
+    HttpError(String),
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 //! # Examples
 //! ```no_run
 //! # #[async_std::main]
-//! # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+//! # async fn main() -> Result<(), surf::Error> {
 //! let mut res = surf::get("https://httpbin.org/get").await?;
 //! dbg!(res.body_string().await?);
 //! # Ok(()) }
@@ -24,7 +24,7 @@
 //! It's also possible to skip the intermediate `Response`, and access the response type directly.
 //! ```no_run
 //! # #[async_std::main]
-//! # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+//! # async fn main() -> Result<(), surf::Error> {
 //! dbg!(surf::get("https://httpbin.org/get").recv_string().await?);
 //! # Ok(()) }
 //! ```
@@ -33,7 +33,7 @@
 //! ```no_run
 //! # use serde::{Deserialize, Serialize};
 //! # #[async_std::main]
-//! # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+//! # async fn main() -> Result<(), surf::Error> {
 //! #[derive(Deserialize, Serialize)]
 //! struct Ip {
 //!     ip: String
@@ -54,7 +54,7 @@
 //!
 //! ```no_run
 //! # #[async_std::main]
-//! # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+//! # async fn main() -> Result<(), surf::Error> {
 //! let reader = surf::get("https://img.fyi/q6YvNqP").await?;
 //! let res = surf::post("https://box.rs/upload").body(reader).await?;
 //! # Ok(()) }
@@ -75,6 +75,7 @@
 #![cfg_attr(test, deny(warnings))]
 
 mod client;
+mod error;
 mod request;
 mod response;
 
@@ -86,6 +87,7 @@ pub use mime;
 pub use url;
 
 pub use client::Client;
+pub use error::{Error, Result};
 pub use request::Request;
 pub use response::{DecodeError, Response};
 
@@ -93,6 +95,3 @@ pub use response::{DecodeError, Response};
 mod one_off;
 #[cfg(feature = "native-client")]
 pub use one_off::{connect, delete, get, head, options, patch, post, put, trace};
-
-/// A generic error type.
-pub type Exception = Box<dyn std::error::Error + Send + Sync + 'static>;

--- a/src/middleware/logger/mod.rs
+++ b/src/middleware/logger/mod.rs
@@ -4,7 +4,7 @@
 //!
 //! ```no_run
 //! # #[async_std::main]
-//! # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+//! # async fn main() -> Result<(), surf::Error> {
 //! let mut res = surf::get("https://httpbin.org/get")
 //!     .middleware(surf::middleware::logger::new())
 //!     .await?;
@@ -30,7 +30,7 @@ use native::Logger;
 ///
 /// ```no_run
 /// # #[async_std::main]
-/// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+/// # async fn main() -> Result<(), surf::Error> {
 /// let mut res = surf::get("https://httpbin.org/get")
 ///     .middleware(surf::middleware::logger::new())
 ///     .await?;

--- a/src/middleware/logger/native.rs
+++ b/src/middleware/logger/native.rs
@@ -1,7 +1,8 @@
 use crate::middleware::{Middleware, Next, Request, Response};
-use http_client::HttpClient;
+use crate::Result;
 
 use futures::future::BoxFuture;
+use http_client::HttpClient;
 use std::fmt::Arguments;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time;
@@ -28,7 +29,7 @@ impl<C: HttpClient> Middleware<C> for Logger {
         req: Request,
         client: C,
         next: Next<'a, C>,
-    ) -> BoxFuture<'a, Result<Response, crate::Exception>> {
+    ) -> BoxFuture<'a, Result<Response>> {
         Box::pin(async move {
             let start_time = time::Instant::now();
             let uri = format!("{}", req.uri());
@@ -80,7 +81,7 @@ impl<'a> log::kv::Source for RequestPairs<'a> {
     fn visit<'kvs>(
         &'kvs self,
         visitor: &mut dyn log::kv::Visitor<'kvs>,
-    ) -> Result<(), log::kv::Error> {
+    ) -> std::result::Result<(), log::kv::Error> {
         visitor.visit_pair("req.id".into(), self.id.into())?;
         visitor.visit_pair("req.method".into(), self.method.into())?;
         visitor.visit_pair("req.uri".into(), self.uri.into())?;
@@ -98,7 +99,7 @@ impl<'a> log::kv::Source for ResponsePairs<'a> {
     fn visit<'kvs>(
         &'kvs self,
         visitor: &mut dyn log::kv::Visitor<'kvs>,
-    ) -> Result<(), log::kv::Error> {
+    ) -> std::result::Result<(), log::kv::Error> {
         visitor.visit_pair("req.id".into(), self.id.into())?;
         visitor.visit_pair("req.status".into(), self.status.into())?;
         visitor.visit_pair("elapsed".into(), self.elapsed.into())?;

--- a/src/middleware/logger/wasm.rs
+++ b/src/middleware/logger/wasm.rs
@@ -25,7 +25,7 @@ impl<C: HttpClient> Middleware<C> for Logger {
         req: Request,
         client: C,
         next: Next<'a, C>,
-    ) -> BoxFuture<'a, Result<Response, crate::Exception>> {
+    ) -> BoxFuture<'a, Result<Response, crate::Error>> {
         Box::pin(async move {
             let uri = format!("{}", req.uri());
             let method = format!("{}", req.method());

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -16,7 +16,7 @@
 //!         req: Request,
 //!         client: C,
 //!         next: Next<'a, C>,
-//!     ) -> BoxFuture<'a, Result<Response, surf::Exception>> {
+//!     ) -> BoxFuture<'a, Result<Response, surf::Error>> {
 //!         Box::pin(async move {
 //!             println!("sending request to {}", req.uri());
 //!             let now = time::Instant::now();
@@ -35,7 +35,7 @@
 //! use surf::middleware::{Next, Middleware, Request, Response, HttpClient};
 //! use std::time;
 //!
-//! fn logger<'a, C: HttpClient>(req: Request, client: C, next: Next<'a, C>) -> BoxFuture<'a, Result<Response, surf::Exception>> {
+//! fn logger<'a, C: HttpClient>(req: Request, client: C, next: Next<'a, C>) -> BoxFuture<'a, Result<Response, surf::Error>> {
 //!     Box::pin(async move {
 //!         println!("sending request to {}", req.uri());
 //!         let now = time::Instant::now();
@@ -51,7 +51,7 @@ pub use http_client::{Body, HttpClient, Request, Response};
 
 pub mod logger;
 
-use crate::Exception;
+use crate::Result;
 use futures::future::BoxFuture;
 use std::sync::Arc;
 
@@ -63,7 +63,7 @@ pub trait Middleware<C: HttpClient>: 'static + Send + Sync {
         req: Request,
         client: C,
         next: Next<'a, C>,
-    ) -> BoxFuture<'a, Result<Response, Exception>>;
+    ) -> BoxFuture<'a, Result<Response>>;
 }
 
 // This allows functions to work as middleware too.
@@ -72,14 +72,14 @@ where
     F: Send
         + Sync
         + 'static
-        + for<'a> Fn(Request, C, Next<'a, C>) -> BoxFuture<'a, Result<Response, Exception>>,
+        + for<'a> Fn(Request, C, Next<'a, C>) -> BoxFuture<'a, Result<Response>>,
 {
     fn handle<'a>(
         &'a self,
         req: Request,
         client: C,
         next: Next<'a, C>,
-    ) -> BoxFuture<'a, Result<Response, Exception>> {
+    ) -> BoxFuture<'a, Result<Response>> {
         (self)(req, client, next)
     }
 }
@@ -88,10 +88,8 @@ where
 #[allow(missing_debug_implementations)]
 pub struct Next<'a, C: HttpClient> {
     next_middleware: &'a [Arc<dyn Middleware<C>>],
-    endpoint: &'a (dyn (Fn(Request, C) -> BoxFuture<'static, Result<Response, Exception>>)
-             + 'static
-             + Send
-             + Sync),
+    endpoint:
+        &'a (dyn (Fn(Request, C) -> BoxFuture<'static, Result<Response>>) + 'static + Send + Sync),
 }
 
 impl<C: HttpClient> Clone for Next<'_, C> {
@@ -109,7 +107,7 @@ impl<'a, C: HttpClient> Next<'a, C> {
     /// Create a new instance
     pub fn new(
         next: &'a [Arc<dyn Middleware<C>>],
-        endpoint: &'a (dyn (Fn(Request, C) -> BoxFuture<'static, Result<Response, Exception>>)
+        endpoint: &'a (dyn (Fn(Request, C) -> BoxFuture<'static, Result<Response>>)
                  + 'static
                  + Send
                  + Sync),
@@ -121,7 +119,7 @@ impl<'a, C: HttpClient> Next<'a, C> {
     }
 
     /// Asynchronously execute the remaining middleware chain.
-    pub fn run(mut self, req: Request, client: C) -> BoxFuture<'a, Result<Response, Exception>> {
+    pub fn run(mut self, req: Request, client: C) -> BoxFuture<'a, Result<Response>> {
         if let Some((current, next)) = self.next_middleware.split_first() {
             self.next_middleware = next;
             current.handle(req, client, self)

--- a/src/one_off.rs
+++ b/src/one_off.rs
@@ -26,7 +26,7 @@ use super::Request;
 ///
 /// ```no_run
 /// # #[async_std::main]
-/// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+/// # async fn main() -> Result<(), surf::Error> {
 /// let string = surf::get("https://httpbin.org/get").recv_string().await?;
 /// # Ok(()) }
 /// ```
@@ -67,7 +67,7 @@ pub fn get(uri: impl AsRef<str>) -> Request<NativeClient> {
 ///
 /// ```no_run
 /// # #[async_std::main]
-/// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+/// # async fn main() -> Result<(), surf::Error> {
 /// let string = surf::head("https://httpbin.org/head").recv_string().await?;
 /// # Ok(()) }
 /// ```
@@ -125,7 +125,7 @@ pub fn head(uri: impl AsRef<str>) -> Request<NativeClient> {
 ///
 /// ```no_run
 /// # #[async_std::main]
-/// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+/// # async fn main() -> Result<(), surf::Error> {
 /// let string = surf::post("https://httpbin.org/post").recv_string().await?;
 /// # Ok(()) }
 /// ```
@@ -161,7 +161,7 @@ pub fn post(uri: impl AsRef<str>) -> Request<NativeClient> {
 ///
 /// ```no_run
 /// # #[async_std::main]
-/// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+/// # async fn main() -> Result<(), surf::Error> {
 /// let string = surf::put("https://httpbin.org/put").recv_string().await?;
 /// # Ok(()) }
 /// ```
@@ -192,7 +192,7 @@ pub fn put(uri: impl AsRef<str>) -> Request<NativeClient> {
 ///
 /// ```no_run
 /// # #[async_std::main]
-/// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+/// # async fn main() -> Result<(), surf::Error> {
 /// let string = surf::delete("https://httpbin.org/delete").recv_string().await?;
 /// # Ok(()) }
 /// ```
@@ -232,7 +232,7 @@ pub fn delete(uri: impl AsRef<str>) -> Request<NativeClient> {
 ///
 /// ```no_run
 /// # #[async_std::main]
-/// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+/// # async fn main() -> Result<(), surf::Error> {
 /// let string = surf::connect("https://httpbin.org/connect").recv_string().await?;
 /// # Ok(()) }
 /// ```
@@ -265,7 +265,7 @@ pub fn connect(uri: impl AsRef<str>) -> Request<NativeClient> {
 ///
 /// ```no_run
 /// # #[async_std::main]
-/// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+/// # async fn main() -> Result<(), surf::Error> {
 /// let string = surf::options("https://httpbin.org/options").recv_string().await?;
 /// # Ok(()) }
 /// ```
@@ -302,7 +302,7 @@ pub fn options(uri: impl AsRef<str>) -> Request<NativeClient> {
 ///
 /// ```no_run
 /// # #[async_std::main]
-/// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+/// # async fn main() -> Result<(), surf::Error> {
 /// let string = surf::trace("https://httpbin.org/trace").recv_string().await?;
 /// # Ok(()) }
 /// ```
@@ -345,7 +345,7 @@ pub fn trace(uri: impl AsRef<str>) -> Request<NativeClient> {
 ///
 /// ```no_run
 /// # #[async_std::main]
-/// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+/// # async fn main() -> Result<(), surf::Error> {
 /// let string = surf::patch("https://httpbin.org/patch").recv_string().await?;
 /// # Ok(()) }
 /// ```

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,7 +1,7 @@
 use mockito::mock;
 
 #[async_std::test]
-async fn post_json() -> Result<(), surf::Exception> {
+async fn post_json() -> anyhow::Result<()> {
     #[derive(serde::Deserialize, serde::Serialize)]
     struct Cat {
         name: String,
@@ -23,7 +23,7 @@ async fn post_json() -> Result<(), surf::Exception> {
 }
 
 #[async_std::test]
-async fn get_json() -> Result<(), surf::Exception> {
+async fn get_json() -> anyhow::Result<()> {
     #[derive(serde::Deserialize)]
     struct Message {
         message: String,


### PR DESCRIPTION
Please note that this is specifically a PoC to replace usage of `Box<dyn std::error::Error + Send + Sync + 'static>` with a concrete `surf::Error` type.

There are a few things yet to figure out:

* Documentation for `surf::{Result, Error}`
* Whether or not the Error variants should be exposed to the end user or if they should be hidden. I went with hiding it because it's similar to `anyhow::Error`.
* When to return a `surf::Error` vs alternatives (like `serde_json::Error`) or if `surf::Error` should always be used
* How errors should be displayed. Should they be wrapped or displayed as-is?

The main `Error` implementation is in `error.rs` and is also exported at the root of the crate.

This is an alternative to simply re-exporting `anyhow::Error` and would be another method of fixing #86.