### PR TITLE
Remove unused dependency feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ encoding = ["encoding_rs"]
 [dependencies]
 futures = { version = "0.3.1", features = ["compat", "io-compat"] }
 http = "0.1.17"
-log = { version = "0.4.7", features = ["kv_unstable"] }
+log = { version = "0.4.7" }
 mime = "0.3.13"
 mime_guess = "2.0.3"
 serde = "1.0.97"


### PR DESCRIPTION
This feature is unused in `surf` and causes havoc with our dependency on `paperclip` (namely `paperclip` doesn't compile due to some type inference problems)