### PR TITLE
Update isahc to 0.9 and http to 0.2.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ encoding = ["encoding_rs"]
 
 [dependencies]
 futures = { version = "0.3.1", features = ["compat", "io-compat"] }
-http = "0.1.17"
+http = "0.2.1"
 log = { version = "0.4.7", features = ["kv_unstable"] }
 mime = "0.3.13"
 mime_guess = "2.0.3"
@@ -30,14 +30,14 @@ serde = "1.0.97"
 serde_json = "1.0.40"
 serde_urlencoded = "0.6.1"
 url = "2.0.0"
-http-client = { version = "1.1.0", features = ["native_client"] }
+http-client = { git = "https://github.com/mythmon/http-client", branch = "isahc-0.9", features = ["native_client"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 # encoding
 encoding_rs = { version = "0.8.20", optional = true }
 
 # isahc-client
-isahc = { version = "0.8", optional = true, default-features = false, features = ["http2"]  }
+isahc = { version = "0.9", optional = true, default-features = false, features = ["http2"]  }
 
 # hyper-client
 hyper = { version = "0.12.32", optional = true, default-features = false }

--- a/src/request.rs
+++ b/src/request.rs
@@ -330,7 +330,7 @@ impl<C: HttpClient> Request<C> {
     /// ```
     pub fn body<R>(mut self, reader: R) -> Self
     where
-        R: AsyncRead + Unpin + Send + 'static,
+        R: AsyncRead + Unpin + Send + Sync + 'static,
     {
         *self.req.as_mut().unwrap().body_mut() = Box::new(reader).into();
         self.set_mime(mime::APPLICATION_OCTET_STREAM)
@@ -592,7 +592,7 @@ impl<C: HttpClient> Future for Request<C> {
 }
 
 #[cfg(feature = "native-client")]
-impl<R: AsyncRead + Unpin + Send + 'static> TryFrom<http::Request<Box<R>>>
+impl<R: AsyncRead + Unpin + Send + Sync + 'static> TryFrom<http::Request<Box<R>>>
     for Request<NativeClient>
 {
     type Error = io::Error;


### PR DESCRIPTION
My approach here was fairly naive. I read the changelog for the two libraries, and then updated the files in Cargo.toml and made changes until it compiled. It's quite possible I've missed something.

This patch depends on [my PR to http-client](https://github.com/http-rs/http-client/pull/24) merging and being released. For now I've set the http-client dependency to point to my git branch, but of course that would need to change before this merges.

Fixes #153 