### PR TITLE
Default to curl-client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 edition = "2018"
 
 [features]
-default = ["h1-client", "middleware-logger", "encoding"]
+default = ["native-client", "middleware-logger", "encoding"]
 h1-client = ["async-h1", "wasm-client"]
 native-client = ["curl-client", "wasm-client", "http-client/native_client"]
 hyper-client = ["hyper", "hyper-tls", "native-tls", "runtime", "runtime-raw", "runtime-tokio" ]


### PR DESCRIPTION
Default to curl for most sessions still. async-h1 is unfortunately still missing e.g. chunked encoding which I think will be limiting for many uses. I think switching over would be fantastic, but think it's probably wise to hold off for a little bit longer. Thanks!