### PR TITLE
re-export `http_types::{Error, Result}` at the crate root

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,7 @@ mod response;
 pub mod middleware;
 
 pub use http_types;
+pub use http_types::Error;
 pub use mime;
 pub use url;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@ mod response;
 pub mod middleware;
 
 pub use http_types;
-pub use http_types::Error;
+pub use http_types::{Error, Result};
 pub use mime;
 pub use url;
 


### PR DESCRIPTION
So you can easily refer to it directly, like:
```rust
async fn some_fn_that_makes_a_request() -> Result<(), surf::Error> {}
```
instead of needing a separate
```rust
use surf::http_types::Error as HttpError;
```