### PR TITLE
Fix set header

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -197,11 +197,7 @@ impl<C: HttpClient> Request<C> {
     /// # Ok(()) }
     /// ```
     pub fn set_header(mut self, key: impl Into<HeaderName>, value: impl ToHeaderValues) -> Self {
-        self.req
-            .as_mut()
-            .unwrap()
-            .insert_header(key, value)
-            .unwrap();
+        self.req.as_mut().unwrap().insert_header(key, value);
         self
     }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -16,7 +16,9 @@ async fn post_json() -> Result<(), http_types::Error> {
         .match_body(&serde_json::to_string(&cat)?[..])
         .with_body(&serde_json::to_string(&cat)?[..])
         .create();
-    let res = surf::post(mockito::server_url()).body_json(&cat)?.await?;
+    let res = surf::post(mockito::server_url())
+        .set_header("Accept", "application/json")
+        .body_json(&cat)?.await?;
     m.assert();
     assert_eq!(res.status(), http_types::StatusCode::Ok);
     Ok(())

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -18,7 +18,8 @@ async fn post_json() -> Result<(), http_types::Error> {
         .create();
     let res = surf::post(mockito::server_url())
         .set_header("Accept", "application/json")
-        .body_json(&cat)?.await?;
+        .body_json(&cat)?
+        .await?;
     m.assert();
     assert_eq!(res.status(), http_types::StatusCode::Ok);
     Ok(())


### PR DESCRIPTION
This fixes #183 - a panic set-header in 0.3. The issue was that `set_header` calls `unwrap()` on the option returned by `insert_header`, which only returns a `Some` if a header already existed.