### PR TITLE
TryFrom to From for surf::Request

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -25,9 +25,6 @@ use http_client::native::NativeClient as Client;
 #[cfg(feature = "h1-client")]
 use http_client::h1::H1Client as Client;
 
-#[cfg(any(feature = "native-client", feature = "h1-client"))]
-use std::convert::TryFrom;
-
 /// An HTTP request, returns a `Response`.
 pub struct Request<C: HttpClient + Debug + Unpin + Send + Sync> {
     /// Holds a `http_client::HttpClient` implementation.
@@ -578,18 +575,16 @@ impl<C: HttpClient> Future for Request<C> {
 }
 
 #[cfg(any(feature = "native-client", feature = "h1-client"))]
-impl TryFrom<http_types::Request> for Request<Client> {
-    type Error = io::Error;
-
+impl From<http_types::Request> for Request<Client> {
     /// Converts an `http_types::Request` to a `surf::Request`.
-    fn try_from(http_request: http_types::Request) -> io::Result<Self> {
+    fn from(http_request: http_types::Request) -> Self {
         let method = http_request.method().clone();
         let url = http_request.url().clone();
-        let req = Self::new(method, url);
         let body: Body = http_request.into();
-        let req = req.body(body);
 
-        Ok(req)
+        let req = Self::new(method, url)
+            .body(body);
+        req
     }
 }
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -578,13 +578,11 @@ impl<C: HttpClient> Future for Request<C> {
 impl From<http_types::Request> for Request<Client> {
     /// Converts an `http_types::Request` to a `surf::Request`.
     fn from(http_request: http_types::Request) -> Self {
-        let method = http_request.method().clone();
+        let method = http_request.method();
         let url = http_request.url().clone();
         let body: Body = http_request.into();
 
-        let req = Self::new(method, url)
-            .body(body);
-        req
+        Self::new(method, url).body(body)
     }
 }
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -655,7 +655,7 @@ impl From<http_types::Request> for Request<Client> {
         let url = http_request.url().clone();
         let req = Self::new(method, url).set_body(http_request);
 
-        Self::new(method, url).body(body)
+        Ok(req)
     }
 }
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -651,11 +651,9 @@ impl<C: HttpClient> Future for Request<C> {
 impl From<http_types::Request> for Request<Client> {
     /// Converts an `http_types::Request` to a `surf::Request`.
     fn from(http_request: http_types::Request) -> Self {
-        let method = http_request.method();
+        let method = http_request.method().clone();
         let url = http_request.url().clone();
-        let req = Self::new(method, url).set_body(http_request);
-
-        Ok(req)
+        Self::new(method, url).set_body(http_request)
     }
 }
 


### PR DESCRIPTION
The current implementation of `TryFrom` succeeds 100% of the time, meaning that it can be safely re-written as a `From` implementation.
This was mentioned in #170.

This is, however, a breaking change.