### PR TITLE
Request, Response: method parity with http-types/tide

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ encoding = ["encoding_rs", "web-sys"]
 [dependencies]
 futures = { version = "0.3.1", features = ["compat", "io-compat"] }
 log = { version = "0.4.7", features = ["kv_unstable"] }
-mime = "0.3.13"
 mime_guess = "2.0.3"
 serde = "1.0.97"
 serde_json = "1.0.40"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@
 //! # #[async_std::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
 //! let req = surf::get("https://img.fyi/q6YvNqP").await?;
-//! let body = surf::http_types::Body::from_reader(req, None);
+//! let body = surf::http::Body::from_reader(req, None);
 //! let res = surf::post("https://box.rs/upload").set_body(body).await?;
 //! # Ok(()) }
 //! ```
@@ -83,9 +83,9 @@ mod response;
 
 pub mod middleware;
 
-pub use http_types;
-pub use http_types::mime;
-pub use http_types::{Error, Result};
+#[doc(inline)]
+pub use http_types::{self as http, Body, Error, Status, StatusCode};
+
 pub use url;
 
 pub use client::Client;
@@ -96,3 +96,6 @@ pub use response::{DecodeError, Response};
 mod one_off;
 #[cfg(any(feature = "native-client", feature = "h1-client"))]
 pub use one_off::{connect, delete, get, head, options, patch, post, put, trace};
+
+/// A specialized Result type for Surf.
+pub type Result<T = Response> = std::result::Result<T, Error>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,8 +55,9 @@
 //! ```no_run
 //! # #[async_std::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
-//! let reader = surf::get("https://img.fyi/q6YvNqP").await?;
-//! let res = surf::post("https://box.rs/upload").body(reader).await?;
+//! let req = surf::get("https://img.fyi/q6YvNqP").await?;
+//! let body = surf::http_types::Body::from_reader(req, None);
+//! let res = surf::post("https://box.rs/upload").set_body(body).await?;
 //! # Ok(()) }
 //! ```
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,8 +84,8 @@ mod response;
 pub mod middleware;
 
 pub use http_types;
+pub use http_types::mime;
 pub use http_types::{Error, Result};
-pub use mime;
 pub use url;
 
 pub use client::Client;

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,10 +1,11 @@
-use async_std::io::BufRead;
-use futures::prelude::*;
-use http_client;
-use http_types::{
+use crate::http::{
     headers::{self, HeaderName, HeaderValues, ToHeaderValues},
     Body, Error, Mime, StatusCode, Version,
 };
+
+use async_std::io::BufRead;
+use futures::prelude::*;
+use http_client;
 use serde::de::DeserializeOwned;
 
 use std::fmt;
@@ -49,7 +50,7 @@ impl Response {
     /// ```no_run
     /// # #[async_std::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
-    /// use surf::http_types::Version;
+    /// use surf::http::Version;
     ///
     /// let res = surf::get("https://httpbin.org/get").await?;
     /// assert_eq!(res.version(), Some(Version::Http1_1));
@@ -145,7 +146,7 @@ impl Response {
     /// ```no_run
     /// # #[async_std::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
-    /// use surf::mime;
+    /// use surf::http::mime;
     /// let res = surf::get("https://httpbin.org/json").await?;
     /// assert_eq!(res.content_type(), Some(mime::JSON));
     /// # Ok(()) }
@@ -210,7 +211,7 @@ impl Response {
     /// let bytes: Vec<u8> = res.body_bytes().await?;
     /// # Ok(()) }
     /// ```
-    pub async fn body_bytes(&mut self) -> http_types::Result<Vec<u8>> {
+    pub async fn body_bytes(&mut self) -> crate::Result<Vec<u8>> {
         self.res.body_bytes().await
     }
 
@@ -244,7 +245,7 @@ impl Response {
     /// let string: String = res.body_string().await?;
     /// # Ok(()) }
     /// ```
-    pub async fn body_string(&mut self) -> http_types::Result<String> {
+    pub async fn body_string(&mut self) -> crate::Result<String> {
         let bytes = self.body_bytes().await?;
         let mime = self.content_type();
         let claimed_encoding = mime
@@ -279,9 +280,9 @@ impl Response {
     /// let Ip { ip } = res.body_json().await?;
     /// # Ok(()) }
     /// ```
-    pub async fn body_json<T: DeserializeOwned>(&mut self) -> http_types::Result<T> {
+    pub async fn body_json<T: DeserializeOwned>(&mut self) -> crate::Result<T> {
         let body_bytes = self.body_bytes().await?;
-        Ok(serde_json::from_slice(&body_bytes).map_err(http_types::Error::from)?)
+        Ok(serde_json::from_slice(&body_bytes).map_err(crate::Error::from)?)
     }
 
     /// Reads and deserialized the entire request body from form encoding.
@@ -309,7 +310,7 @@ impl Response {
     /// let Body { apples } = res.body_form().await?;
     /// # Ok(()) }
     /// ```
-    pub async fn body_form<T: serde::de::DeserializeOwned>(&mut self) -> http_types::Result<T> {
+    pub async fn body_form<T: serde::de::DeserializeOwned>(&mut self) -> crate::Result<T> {
         self.res.body_form().await
     }
 }

--- a/src/response.rs
+++ b/src/response.rs
@@ -18,14 +18,14 @@ pin_project_lite::pin_project! {
     /// An HTTP response, returned by `Request`.
     pub struct Response {
         #[pin]
-        response: http_client::Response,
+        res: http_client::Response,
     }
 }
 
 impl Response {
     /// Create a new instance.
-    pub(crate) fn new(response: http_client::Response) -> Self {
-        Self { response }
+    pub(crate) fn new(res: http_client::Response) -> Self {
+        Self { res }
     }
 
     /// Get the HTTP status code.
@@ -40,7 +40,7 @@ impl Response {
     /// # Ok(()) }
     /// ```
     pub fn status(&self) -> StatusCode {
-        self.response.status()
+        self.res.status()
     }
 
     /// Get the HTTP protocol version.
@@ -57,7 +57,7 @@ impl Response {
     /// # Ok(()) }
     /// ```
     pub fn version(&self) -> Option<Version> {
-        self.response.version()
+        self.res.version()
     }
 
     /// Get a header.
@@ -72,7 +72,7 @@ impl Response {
     /// # Ok(()) }
     /// ```
     pub fn header(&self, key: impl Into<HeaderName>) -> Option<&HeaderValues> {
-        self.response.header(key)
+        self.res.header(key)
     }
 
     /// Get the request MIME.
@@ -121,7 +121,7 @@ impl Response {
     /// ```
     pub async fn body_bytes(&mut self) -> io::Result<Vec<u8>> {
         let mut buf = Vec::with_capacity(1024);
-        self.response.read_to_end(&mut buf).await?;
+        self.res.read_to_end(&mut buf).await?;
         Ok(buf)
     }
 
@@ -234,7 +234,7 @@ impl AsyncRead for Response {
         cx: &mut Context<'_>,
         buf: &mut [u8],
     ) -> Poll<Result<usize, io::Error>> {
-        Pin::new(&mut self.response).poll_read(cx, buf)
+        Pin::new(&mut self.res).poll_read(cx, buf)
     }
 }
 
@@ -242,11 +242,11 @@ impl BufRead for Response {
     #[allow(missing_doc_code_examples)]
     fn poll_fill_buf(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<&'_ [u8]>> {
         let this = self.project();
-        this.response.poll_fill_buf(cx)
+        this.res.poll_fill_buf(cx)
     }
 
     fn consume(mut self: Pin<&mut Self>, amt: usize) {
-        Pin::new(&mut self.response).consume(amt)
+        Pin::new(&mut self.res).consume(amt)
     }
 }
 
@@ -254,7 +254,7 @@ impl fmt::Debug for Response {
     #[allow(missing_doc_code_examples)]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Response")
-            .field("response", &self.response)
+            .field("response", &self.res)
             .finish()
     }
 }


### PR DESCRIPTION
Adds many methods on http_types request/response that Tide exposes.

Supercedes the following PRs:
- #182
- #174
- #171

Also changes the "mime" / "content_type" apis to use `http_types::mime` like Tide, which is a breaking change.