### PR TITLE
dyn HttpClient

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ serde = "1.0.97"
 serde_json = "1.0.40"
 serde_urlencoded = "0.6.1"
 url = "2.0.0"
-http-client = "3.0.0"
+http-client = "4.0.0"
 http-types = "2.0.0"
 async-std = { version = "1.6.0", default-features = false, features = ["std"] }
 pin-project-lite = "0.1.1"

--- a/examples/middleware.rs
+++ b/examples/middleware.rs
@@ -1,5 +1,6 @@
 use async_std::task;
 use futures::future::BoxFuture;
+use std::sync::Arc;
 use surf::middleware::{HttpClient, Middleware, Next, Request, Response};
 
 struct Printer;
@@ -8,7 +9,7 @@ impl Middleware for Printer {
     fn handle<'a>(
         &'a self,
         req: Request,
-        client: Box<dyn HttpClient>,
+        client: Arc<dyn HttpClient>,
         next: Next<'a>,
     ) -> BoxFuture<'a, Result<Response, http_types::Error>> {
         Box::pin(async move {

--- a/examples/middleware.rs
+++ b/examples/middleware.rs
@@ -4,12 +4,12 @@ use surf::middleware::{HttpClient, Middleware, Next, Request, Response};
 
 struct Printer;
 
-impl<C: HttpClient> Middleware<C> for Printer {
+impl Middleware for Printer {
     fn handle<'a>(
         &'a self,
         req: Request,
-        client: C,
-        next: Next<'a, C>,
+        client: Box<dyn HttpClient>,
+        next: Next<'a>,
     ) -> BoxFuture<'a, Result<Response, http_types::Error>> {
         Box::pin(async move {
             println!("sending a request!");

--- a/examples/next_reuse.rs
+++ b/examples/next_reuse.rs
@@ -5,12 +5,12 @@ use surf::middleware::{Body, HttpClient, Middleware, Next, Request, Response};
 
 struct Doubler;
 
-impl<C: HttpClient> Middleware<C> for Doubler {
+impl Middleware for Doubler {
     fn handle<'a>(
         &'a self,
         req: Request,
-        client: C,
-        next: Next<'a, C>,
+        client: Box<dyn HttpClient>,
+        next: Next<'a>,
     ) -> BoxFuture<'a, Result<Response, http_types::Error>> {
         if req.method().is_safe() {
             Box::pin(async move {

--- a/examples/next_reuse.rs
+++ b/examples/next_reuse.rs
@@ -1,6 +1,7 @@
 use async_std::task;
 use futures::future::BoxFuture;
 use futures::io::AsyncReadExt;
+use std::sync::Arc;
 use surf::middleware::{Body, HttpClient, Middleware, Next, Request, Response};
 
 struct Doubler;
@@ -9,7 +10,7 @@ impl Middleware for Doubler {
     fn handle<'a>(
         &'a self,
         req: Request,
-        client: Box<dyn HttpClient>,
+        client: Arc<dyn HttpClient>,
         next: Next<'a>,
     ) -> BoxFuture<'a, Result<Response, http_types::Error>> {
         if req.method().is_safe() {

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,5 +1,9 @@
+use std::fmt;
+use std::sync::Arc;
+
 use crate::http::Method;
 use crate::Request;
+
 use http_client::HttpClient;
 
 #[cfg(feature = "native-client")]
@@ -21,9 +25,14 @@ use http_client::h1::H1Client;
 /// let (str1, str2) = futures::future::try_join(req1, req2).await?;
 /// # Ok(()) }
 /// ```
-#[derive(Debug)]
 pub struct Client {
-    client: Box<dyn HttpClient>,
+    client: Arc<dyn HttpClient>,
+}
+
+impl fmt::Debug for Client {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Client {{}}")
+    }
 }
 
 #[cfg(feature = "native-client")]
@@ -39,7 +48,7 @@ impl Client {
     /// # Ok(()) }
     /// ```
     pub fn new() -> Self {
-        Self::with_client(Box::new(NativeClient::new()))
+        Self::with_client(Arc::new(NativeClient::new()))
     }
 }
 
@@ -56,7 +65,7 @@ impl Client {
     /// # Ok(()) }
     /// ```
     pub fn new() -> Self {
-        Self::with_client(H1Client::new())
+        Self::with_client(Arc::new(H1Client::new()))
     }
 }
 
@@ -65,7 +74,7 @@ impl Client {
     // TODO(yw): hidden from docs until we make the traits public.
     #[doc(hidden)]
     #[allow(missing_doc_code_examples)]
-    pub fn with_client(client: Box<dyn HttpClient>) -> Self {
+    pub fn with_client(client: Arc<dyn HttpClient>) -> Self {
         Self { client }
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -6,7 +6,7 @@ use crate::Request;
 
 use http_client::HttpClient;
 
-#[cfg(feature = "native-client")]
+#[cfg(all(feature = "native-client", not(feature = "h1-client")))]
 use http_client::native::NativeClient;
 
 #[cfg(feature = "h1-client")]
@@ -35,7 +35,6 @@ impl fmt::Debug for Client {
     }
 }
 
-#[cfg(feature = "native-client")]
 impl Client {
     /// Create a new instance.
     ///
@@ -48,24 +47,11 @@ impl Client {
     /// # Ok(()) }
     /// ```
     pub fn new() -> Self {
-        Self::with_client(Arc::new(NativeClient::new()))
-    }
-}
-
-#[cfg(feature = "h1-client")]
-impl Client {
-    /// Create a new instance.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// # #[async_std::main]
-    /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
-    /// let client = surf::Client::new();
-    /// # Ok(()) }
-    /// ```
-    pub fn new() -> Self {
-        Self::with_client(Arc::new(H1Client::new()))
+        #[cfg(all(feature = "native-client", not(feature = "h1-client")))]
+        let client = NativeClient::new();
+        #[cfg(feature = "h1-client")]
+        let client = H1Client::new();
+        Self::with_client(Arc::new(client))
     }
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,3 +1,4 @@
+use crate::http::Method;
 use crate::Request;
 use http_client::HttpClient;
 
@@ -20,13 +21,13 @@ use http_client::h1::H1Client;
 /// let (str1, str2) = futures::future::try_join(req1, req2).await?;
 /// # Ok(()) }
 /// ```
-#[derive(Debug, Default)]
-pub struct Client<C: HttpClient> {
-    client: C,
+#[derive(Debug)]
+pub struct Client {
+    client: Box<dyn HttpClient>,
 }
 
 #[cfg(feature = "native-client")]
-impl Client<NativeClient> {
+impl Client {
     /// Create a new instance.
     ///
     /// # Examples
@@ -38,12 +39,12 @@ impl Client<NativeClient> {
     /// # Ok(()) }
     /// ```
     pub fn new() -> Self {
-        Self::with_client(NativeClient::new())
+        Self::with_client(Box::new(NativeClient::new()))
     }
 }
 
 #[cfg(feature = "h1-client")]
-impl Client<H1Client> {
+impl Client {
     /// Create a new instance.
     ///
     /// # Examples
@@ -59,13 +60,12 @@ impl Client<H1Client> {
     }
 }
 
-impl<C: HttpClient> Client<C> {
+impl Client {
     /// Create a new instance with an `http_client::HttpClient` instance.
     // TODO(yw): hidden from docs until we make the traits public.
     #[doc(hidden)]
     #[allow(missing_doc_code_examples)]
-    pub fn with_client(client: C) -> Self {
-        let client = client;
+    pub fn with_client(client: Box<dyn HttpClient>) -> Self {
         Self { client }
     }
 
@@ -88,9 +88,9 @@ impl<C: HttpClient> Client<C> {
     /// let string = client.get("https://httpbin.org/get").recv_string().await?;
     /// # Ok(()) }
     /// ```
-    pub fn get(&self, uri: impl AsRef<str>) -> Request<C> {
+    pub fn get(&self, uri: impl AsRef<str>) -> Request {
         let uri = uri.as_ref().parse().unwrap();
-        Request::with_client(http_types::Method::Get, uri, self.client.clone())
+        Request::with_client(Method::Get, uri, self.client.clone())
     }
 
     /// Perform an HTTP `HEAD` request using the `Client` connection.
@@ -112,9 +112,9 @@ impl<C: HttpClient> Client<C> {
     /// let string = client.head("https://httpbin.org/head").recv_string().await?;
     /// # Ok(()) }
     /// ```
-    pub fn head(&self, uri: impl AsRef<str>) -> Request<C> {
+    pub fn head(&self, uri: impl AsRef<str>) -> Request {
         let uri = uri.as_ref().parse().unwrap();
-        Request::with_client(http_types::Method::Head, uri, self.client.clone())
+        Request::with_client(Method::Head, uri, self.client.clone())
     }
 
     /// Perform an HTTP `POST` request using the `Client` connection.
@@ -136,9 +136,9 @@ impl<C: HttpClient> Client<C> {
     /// let string = client.post("https://httpbin.org/post").recv_string().await?;
     /// # Ok(()) }
     /// ```
-    pub fn post(&self, uri: impl AsRef<str>) -> Request<C> {
+    pub fn post(&self, uri: impl AsRef<str>) -> Request {
         let uri = uri.as_ref().parse().unwrap();
-        Request::with_client(http_types::Method::Post, uri, self.client.clone())
+        Request::with_client(Method::Post, uri, self.client.clone())
     }
 
     /// Perform an HTTP `PUT` request using the `Client` connection.
@@ -160,9 +160,9 @@ impl<C: HttpClient> Client<C> {
     /// let string = client.put("https://httpbin.org/put").recv_string().await?;
     /// # Ok(()) }
     /// ```
-    pub fn put(&self, uri: impl AsRef<str>) -> Request<C> {
+    pub fn put(&self, uri: impl AsRef<str>) -> Request {
         let uri = uri.as_ref().parse().unwrap();
-        Request::with_client(http_types::Method::Put, uri, self.client.clone())
+        Request::with_client(Method::Put, uri, self.client.clone())
     }
 
     /// Perform an HTTP `DELETE` request using the `Client` connection.
@@ -184,9 +184,9 @@ impl<C: HttpClient> Client<C> {
     /// let string = client.delete("https://httpbin.org/delete").recv_string().await?;
     /// # Ok(()) }
     /// ```
-    pub fn delete(&self, uri: impl AsRef<str>) -> Request<C> {
+    pub fn delete(&self, uri: impl AsRef<str>) -> Request {
         let uri = uri.as_ref().parse().unwrap();
-        Request::with_client(http_types::Method::Delete, uri, self.client.clone())
+        Request::with_client(Method::Delete, uri, self.client.clone())
     }
 
     /// Perform an HTTP `CONNECT` request using the `Client` connection.
@@ -208,9 +208,9 @@ impl<C: HttpClient> Client<C> {
     /// let string = client.connect("https://httpbin.org/connect").recv_string().await?;
     /// # Ok(()) }
     /// ```
-    pub fn connect(&self, uri: impl AsRef<str>) -> Request<C> {
+    pub fn connect(&self, uri: impl AsRef<str>) -> Request {
         let uri = uri.as_ref().parse().unwrap();
-        Request::with_client(http_types::Method::Connect, uri, self.client.clone())
+        Request::with_client(Method::Connect, uri, self.client.clone())
     }
 
     /// Perform an HTTP `OPTIONS` request using the `Client` connection.
@@ -232,9 +232,9 @@ impl<C: HttpClient> Client<C> {
     /// let string = client.options("https://httpbin.org/options").recv_string().await?;
     /// # Ok(()) }
     /// ```
-    pub fn options(&self, uri: impl AsRef<str>) -> Request<C> {
+    pub fn options(&self, uri: impl AsRef<str>) -> Request {
         let uri = uri.as_ref().parse().unwrap();
-        Request::with_client(http_types::Method::Options, uri, self.client.clone())
+        Request::with_client(Method::Options, uri, self.client.clone())
     }
 
     /// Perform an HTTP `TRACE` request using the `Client` connection.
@@ -256,9 +256,9 @@ impl<C: HttpClient> Client<C> {
     /// let string = client.trace("https://httpbin.org/trace").recv_string().await?;
     /// # Ok(()) }
     /// ```
-    pub fn trace(&self, uri: impl AsRef<str>) -> Request<C> {
+    pub fn trace(&self, uri: impl AsRef<str>) -> Request {
         let uri = uri.as_ref().parse().unwrap();
-        Request::with_client(http_types::Method::Trace, uri, self.client.clone())
+        Request::with_client(Method::Trace, uri, self.client.clone())
     }
 
     /// Perform an HTTP `PATCH` request using the `Client` connection.
@@ -280,8 +280,8 @@ impl<C: HttpClient> Client<C> {
     /// let string = client.patch("https://httpbin.org/patch").recv_string().await?;
     /// # Ok(()) }
     /// ```
-    pub fn patch(&self, uri: impl AsRef<str>) -> Request<C> {
+    pub fn patch(&self, uri: impl AsRef<str>) -> Request {
         let uri = uri.as_ref().parse().unwrap();
-        Request::with_client(http_types::Method::Patch, uri, self.client.clone())
+        Request::with_client(Method::Patch, uri, self.client.clone())
     }
 }

--- a/src/middleware/logger/native.rs
+++ b/src/middleware/logger/native.rs
@@ -21,13 +21,13 @@ impl Logger {
     }
 }
 
-impl<C: HttpClient> Middleware<C> for Logger {
+impl Middleware for Logger {
     #[allow(missing_doc_code_examples)]
     fn handle<'a>(
         &'a self,
         req: Request,
-        client: C,
-        next: Next<'a, C>,
+        client: Box<dyn HttpClient>,
+        next: Next<'a>,
     ) -> BoxFuture<'a, Result<Response, http_types::Error>> {
         Box::pin(async move {
             let start_time = time::Instant::now();

--- a/src/middleware/logger/native.rs
+++ b/src/middleware/logger/native.rs
@@ -4,6 +4,7 @@ use http_client::HttpClient;
 use futures::future::BoxFuture;
 use std::fmt::Arguments;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 use std::time;
 
 static COUNTER: AtomicUsize = AtomicUsize::new(0);
@@ -26,7 +27,7 @@ impl Middleware for Logger {
     fn handle<'a>(
         &'a self,
         req: Request,
-        client: Box<dyn HttpClient>,
+        client: Arc<dyn HttpClient>,
         next: Next<'a>,
     ) -> BoxFuture<'a, Result<Response, http_types::Error>> {
         Box::pin(async move {

--- a/src/middleware/logger/wasm.rs
+++ b/src/middleware/logger/wasm.rs
@@ -4,6 +4,7 @@ use http_client::HttpClient;
 use futures::future::BoxFuture;
 
 use std::fmt::Arguments;
+use std::sync::Arc;
 
 /// Log each request's duration.
 #[derive(Debug)]
@@ -23,7 +24,7 @@ impl Middleware for Logger {
     fn handle<'a>(
         &'a self,
         req: Request,
-        client: Box<dyn HttpClient>,
+        client: Arc<dyn HttpClient>,
         next: Next<'a>,
     ) -> BoxFuture<'a, Result<Response, http_types::Error>> {
         Box::pin(async move {

--- a/src/middleware/logger/wasm.rs
+++ b/src/middleware/logger/wasm.rs
@@ -18,13 +18,13 @@ impl Logger {
     }
 }
 
-impl<C: HttpClient> Middleware<C> for Logger {
+impl Middleware for Logger {
     #[allow(missing_doc_code_examples)]
     fn handle<'a>(
         &'a self,
         req: Request,
-        client: C,
-        next: Next<'a, C>,
+        client: Box<dyn HttpClient>,
+        next: Next<'a>,
     ) -> BoxFuture<'a, Result<Response, http_types::Error>> {
         Box::pin(async move {
             let uri = format!("{}", req.uri());

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -4,18 +4,19 @@
 //! ```no_run
 //! use futures::future::BoxFuture;
 //! use surf::middleware::{Next, Middleware, Request, Response, HttpClient};
+//! use std::error::Error;
 //! use std::time;
 //!
 //! /// Log each request's duration
 //! #[derive(Debug)]
 //! pub struct Logger;
 //!
-//! impl<C: HttpClient> Middleware<C> for Logger {
+//! impl Middleware for Logger {
 //!     fn handle<'a>(
 //!         &'a self,
 //!         req: Request,
-//!         client: C,
-//!         next: Next<'a, C>,
+//!         client: Box<dyn HttpClient>,
+//!         next: Next<'a>,
 //!     ) -> BoxFuture<'a, Result<Response, http_types::Error>> {
 //!         Box::pin(async move {
 //!             println!("sending request to {}", req.url());
@@ -35,7 +36,7 @@
 //! use surf::middleware::{Next, Middleware, Request, Response, HttpClient};
 //! use std::time;
 //!
-//! fn logger<'a, C: HttpClient>(req: Request, client: C, next: Next<'a, C>) -> BoxFuture<'a, Result<Response, http_types::Error>> {
+//! fn logger<'a>(req: Request, client: Box<dyn HttpClient>, next: Next<'a>) -> BoxFuture<'a, Result<Response, http_types::Error>> {
 //!     Box::pin(async move {
 //!         println!("sending request to {}", req.url());
 //!         let now = time::Instant::now();
@@ -56,29 +57,29 @@ use http_types::Error;
 use std::sync::Arc;
 
 /// Middleware that wraps around remaining middleware chain.
-pub trait Middleware<C: HttpClient>: 'static + Send + Sync {
+pub trait Middleware: 'static + Send + Sync {
     /// Asynchronously handle the request, and return a response.
     fn handle<'a>(
         &'a self,
         req: Request,
-        client: C,
-        next: Next<'a, C>,
+        client: Box<dyn HttpClient>,
+        next: Next<'a>,
     ) -> BoxFuture<'a, Result<Response, Error>>;
 }
 
 // This allows functions to work as middleware too.
-impl<F, C: HttpClient> Middleware<C> for F
+impl<F> Middleware for F
 where
     F: Send
         + Sync
         + 'static
-        + for<'a> Fn(Request, C, Next<'a, C>) -> BoxFuture<'a, Result<Response, Error>>,
+        + for<'a> Fn(Request, Box<dyn HttpClient>, Next<'a>) -> BoxFuture<'a, Result<Response, Error>>,
 {
     fn handle<'a>(
         &'a self,
         req: Request,
-        client: C,
-        next: Next<'a, C>,
+        client: Box<dyn HttpClient>,
+        next: Next<'a>,
     ) -> BoxFuture<'a, Result<Response, Error>> {
         (self)(req, client, next)
     }
@@ -86,15 +87,15 @@ where
 
 /// The remainder of a middleware chain, including the endpoint.
 #[allow(missing_debug_implementations)]
-pub struct Next<'a, C: HttpClient> {
-    next_middleware: &'a [Arc<dyn Middleware<C>>],
-    endpoint: &'a (dyn (Fn(Request, C) -> BoxFuture<'static, Result<Response, Error>>)
+pub struct Next<'a> {
+    next_middleware: &'a [Arc<dyn Middleware>],
+    endpoint: &'a (dyn (Fn(Request, Box<dyn HttpClient>) -> BoxFuture<'static, Result<Response, Error>>)
              + 'static
              + Send
              + Sync),
 }
 
-impl<C: HttpClient> Clone for Next<'_, C> {
+impl Clone for Next<'_> {
     fn clone(&self) -> Self {
         Self {
             next_middleware: self.next_middleware,
@@ -103,13 +104,13 @@ impl<C: HttpClient> Clone for Next<'_, C> {
     }
 }
 
-impl<C: HttpClient> Copy for Next<'_, C> {}
+impl Copy for Next<'_> {}
 
-impl<'a, C: HttpClient> Next<'a, C> {
+impl<'a> Next<'a> {
     /// Create a new instance
     pub fn new(
-        next: &'a [Arc<dyn Middleware<C>>],
-        endpoint: &'a (dyn (Fn(Request, C) -> BoxFuture<'static, Result<Response, Error>>)
+        next: &'a [Arc<dyn Middleware>],
+        endpoint: &'a (dyn (Fn(Request, Box<dyn HttpClient>) -> BoxFuture<'static, Result<Response, Error>>)
                  + 'static
                  + Send
                  + Sync),
@@ -121,7 +122,11 @@ impl<'a, C: HttpClient> Next<'a, C> {
     }
 
     /// Asynchronously execute the remaining middleware chain.
-    pub fn run(mut self, req: Request, client: C) -> BoxFuture<'a, Result<Response, Error>> {
+    pub fn run(
+        mut self,
+        req: Request,
+        client: Box<dyn HttpClient>,
+    ) -> BoxFuture<'a, Result<Response, Error>> {
         if let Some((current, next)) = self.next_middleware.split_first() {
             self.next_middleware = next;
             current.handle(req, client, self)

--- a/src/one_off.rs
+++ b/src/one_off.rs
@@ -1,10 +1,5 @@
-#[cfg(feature = "native-client")]
-use http_client::native::NativeClient as Client;
-
-#[cfg(feature = "h1-client")]
-use http_client::h1::H1Client as Client;
-
 use super::Request;
+use crate::http::Method;
 
 /// Perform a one-off `GET` request.
 ///
@@ -33,9 +28,9 @@ use super::Request;
 /// let string = surf::get("https://httpbin.org/get").recv_string().await?;
 /// # Ok(()) }
 /// ```
-pub fn get(uri: impl AsRef<str>) -> Request<Client> {
+pub fn get(uri: impl AsRef<str>) -> Request {
     let uri = uri.as_ref().parse().unwrap();
-    Request::new(http_types::Method::Get, uri)
+    Request::new(Method::Get, uri)
 }
 
 /// Perform a one-off `HEAD` request.
@@ -74,9 +69,9 @@ pub fn get(uri: impl AsRef<str>) -> Request<Client> {
 /// let string = surf::head("https://httpbin.org/head").recv_string().await?;
 /// # Ok(()) }
 /// ```
-pub fn head(uri: impl AsRef<str>) -> Request<Client> {
+pub fn head(uri: impl AsRef<str>) -> Request {
     let uri = uri.as_ref().parse().unwrap();
-    Request::new(http_types::Method::Head, uri)
+    Request::new(Method::Head, uri)
 }
 
 /// Perform a one-off `POST` request.
@@ -132,9 +127,9 @@ pub fn head(uri: impl AsRef<str>) -> Request<Client> {
 /// let string = surf::post("https://httpbin.org/post").recv_string().await?;
 /// # Ok(()) }
 /// ```
-pub fn post(uri: impl AsRef<str>) -> Request<Client> {
+pub fn post(uri: impl AsRef<str>) -> Request {
     let uri = uri.as_ref().parse().unwrap();
-    Request::new(http_types::Method::Post, uri)
+    Request::new(Method::Post, uri)
 }
 
 /// Perform a one-off `PUT` request.
@@ -168,9 +163,9 @@ pub fn post(uri: impl AsRef<str>) -> Request<Client> {
 /// let string = surf::put("https://httpbin.org/put").recv_string().await?;
 /// # Ok(()) }
 /// ```
-pub fn put(uri: impl AsRef<str>) -> Request<Client> {
+pub fn put(uri: impl AsRef<str>) -> Request {
     let uri = uri.as_ref().parse().unwrap();
-    Request::new(http_types::Method::Put, uri)
+    Request::new(Method::Put, uri)
 }
 
 /// Perform a one-off `DELETE` request.
@@ -199,9 +194,9 @@ pub fn put(uri: impl AsRef<str>) -> Request<Client> {
 /// let string = surf::delete("https://httpbin.org/delete").recv_string().await?;
 /// # Ok(()) }
 /// ```
-pub fn delete(uri: impl AsRef<str>) -> Request<Client> {
+pub fn delete(uri: impl AsRef<str>) -> Request {
     let uri = uri.as_ref().parse().unwrap();
-    Request::new(http_types::Method::Delete, uri)
+    Request::new(Method::Delete, uri)
 }
 
 /// Perform a one-off `CONNECT` request.
@@ -239,9 +234,9 @@ pub fn delete(uri: impl AsRef<str>) -> Request<Client> {
 /// let string = surf::connect("https://httpbin.org/connect").recv_string().await?;
 /// # Ok(()) }
 /// ```
-pub fn connect(uri: impl AsRef<str>) -> Request<Client> {
+pub fn connect(uri: impl AsRef<str>) -> Request {
     let uri = uri.as_ref().parse().unwrap();
-    Request::new(http_types::Method::Connect, uri)
+    Request::new(Method::Connect, uri)
 }
 
 /// Perform a one-off `OPTIONS` request.
@@ -272,9 +267,9 @@ pub fn connect(uri: impl AsRef<str>) -> Request<Client> {
 /// let string = surf::options("https://httpbin.org/options").recv_string().await?;
 /// # Ok(()) }
 /// ```
-pub fn options(uri: impl AsRef<str>) -> Request<Client> {
+pub fn options(uri: impl AsRef<str>) -> Request {
     let uri = uri.as_ref().parse().unwrap();
-    Request::new(http_types::Method::Options, uri)
+    Request::new(Method::Options, uri)
 }
 
 /// Perform a one-off `TRACE` request.
@@ -309,9 +304,9 @@ pub fn options(uri: impl AsRef<str>) -> Request<Client> {
 /// let string = surf::trace("https://httpbin.org/trace").recv_string().await?;
 /// # Ok(()) }
 /// ```
-pub fn trace(uri: impl AsRef<str>) -> Request<Client> {
+pub fn trace(uri: impl AsRef<str>) -> Request {
     let uri = uri.as_ref().parse().unwrap();
-    Request::new(http_types::Method::Trace, uri)
+    Request::new(Method::Trace, uri)
 }
 
 /// Perform a one-off `PATCH` request.
@@ -352,7 +347,7 @@ pub fn trace(uri: impl AsRef<str>) -> Request<Client> {
 /// let string = surf::patch("https://httpbin.org/patch").recv_string().await?;
 /// # Ok(()) }
 /// ```
-pub fn patch(uri: impl AsRef<str>) -> Request<Client> {
+pub fn patch(uri: impl AsRef<str>) -> Request {
     let uri = uri.as_ref().parse().unwrap();
-    Request::new(http_types::Method::Patch, uri)
+    Request::new(Method::Patch, uri)
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -20,7 +20,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
-#[cfg(feature = "native-client")]
+#[cfg(all(feature = "native-client", not(feature = "h1-client")))]
 use http_client::native::NativeClient;
 
 #[cfg(feature = "h1-client")]
@@ -40,7 +40,6 @@ pub struct Request {
     url: Url,
 }
 
-#[cfg(any(feature = "native-client", feature = "h1-client"))]
 impl Request {
     /// Create a new instance.
     ///
@@ -62,7 +61,11 @@ impl Request {
     /// # Ok(()) }
     /// ```
     pub fn new(method: Method, url: Url) -> Self {
-        Self::with_client(method, url, Arc::new(NativeClient::new()))
+        #[cfg(all(feature = "native-client", not(feature = "h1-client")))]
+        let client = NativeClient::new();
+        #[cfg(feature = "h1-client")]
+        let client = H1Client::new();
+        Self::with_client(method, url, Arc::new(client))
     }
 }
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -29,7 +29,7 @@ use http_client::h1::H1Client;
 /// An HTTP request, returns a `Response`.
 pub struct Request {
     /// Holds a `http_client::HttpClient` implementation.
-    client: Option<Box<dyn HttpClient>>,
+    client: Option<Arc<dyn HttpClient>>,
     /// Holds the state of the request.
     req: Option<http_client::Request>,
     /// Holds the inner middleware.
@@ -62,7 +62,7 @@ impl Request {
     /// # Ok(()) }
     /// ```
     pub fn new(method: Method, url: Url) -> Self {
-        Self::with_client(method, url, Box::new(NativeClient::new()))
+        Self::with_client(method, url, Arc::new(NativeClient::new()))
     }
 }
 
@@ -71,7 +71,7 @@ impl Request {
     // TODO(yw): hidden from docs until we make the traits public.
     #[doc(hidden)]
     #[allow(missing_doc_code_examples)]
-    pub fn with_client(method: Method, url: Url, client: Box<dyn HttpClient>) -> Self {
+    pub fn with_client(method: Method, url: Url, client: Arc<dyn HttpClient>) -> Self {
         let req = http_client::Request::new(method, url.clone());
         let client = Self {
             fut: None,

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,4 +1,5 @@
 use crate::http::{
+    self,
     headers::{self, HeaderName, HeaderValues, ToHeaderValues},
     Body, Error, Method, Mime,
 };
@@ -11,7 +12,6 @@ use serde::Serialize;
 use url::Url;
 
 use std::fmt;
-use std::fmt::Debug;
 use std::future::Future;
 use std::io;
 use std::ops::Index;
@@ -21,19 +21,19 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 #[cfg(feature = "native-client")]
-use http_client::native::NativeClient as Client;
+use http_client::native::NativeClient;
 
 #[cfg(feature = "h1-client")]
-use http_client::h1::H1Client as Client;
+use http_client::h1::H1Client;
 
 /// An HTTP request, returns a `Response`.
-pub struct Request<C: HttpClient + Debug + Unpin + Send + Sync> {
+pub struct Request {
     /// Holds a `http_client::HttpClient` implementation.
-    client: Option<C>,
+    client: Option<Box<dyn HttpClient>>,
     /// Holds the state of the request.
     req: Option<http_client::Request>,
     /// Holds the inner middleware.
-    middleware: Option<Vec<Arc<dyn Middleware<C>>>>,
+    middleware: Option<Vec<Arc<dyn Middleware>>>,
     /// Holds the state of the `impl Future`.
     fut: Option<BoxFuture<'static, Result<Response, Error>>>,
     /// Holds a reference to the Url
@@ -41,7 +41,7 @@ pub struct Request<C: HttpClient + Debug + Unpin + Send + Sync> {
 }
 
 #[cfg(any(feature = "native-client", feature = "h1-client"))]
-impl Request<Client> {
+impl Request {
     /// Create a new instance.
     ///
     /// This method is particularly useful when input URLs might be passed by third parties, and
@@ -62,18 +62,17 @@ impl Request<Client> {
     /// # Ok(()) }
     /// ```
     pub fn new(method: Method, url: Url) -> Self {
-        Self::with_client(method, url, Client::new())
+        Self::with_client(method, url, Box::new(NativeClient::new()))
     }
 }
 
-impl<C: HttpClient> Request<C> {
+impl Request {
     /// Create a new instance with an `HttpClient` instance.
     // TODO(yw): hidden from docs until we make the traits public.
     #[doc(hidden)]
     #[allow(missing_doc_code_examples)]
-    pub fn with_client(method: Method, url: Url, client: C) -> Self {
+    pub fn with_client(method: Method, url: Url, client: Box<dyn HttpClient>) -> Self {
         let req = http_client::Request::new(method, url.clone());
-
         let client = Self {
             fut: None,
             client: Some(client),
@@ -104,7 +103,7 @@ impl<C: HttpClient> Request<C> {
     ///     .await?;
     /// # Ok(()) }
     /// ```
-    pub fn middleware(mut self, mw: impl Middleware<C>) -> Self {
+    pub fn middleware(mut self, mw: impl Middleware) -> Self {
         self.middleware.as_mut().unwrap().push(Arc::new(mw));
         self
     }
@@ -622,7 +621,7 @@ impl<C: HttpClient> Request<C> {
     }
 }
 
-impl<C: HttpClient> Future for Request<C> {
+impl Future for Request {
     type Output = Result<Response, Error>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
@@ -648,30 +647,30 @@ impl<C: HttpClient> Future for Request<C> {
 }
 
 #[cfg(any(feature = "native-client", feature = "h1-client"))]
-impl From<http_types::Request> for Request<Client> {
-    /// Converts an `http_types::Request` to a `surf::Request`.
-    fn from(http_request: http_types::Request) -> Self {
+impl From<http::Request> for Request {
+    /// Converts an `http::Request` to a `surf::Request`.
+    fn from(http_request: http::Request) -> Self {
         let method = http_request.method().clone();
         let url = http_request.url().clone();
         Self::new(method, url).set_body(http_request)
     }
 }
 
-impl<C: HttpClient> Into<http_types::Request> for Request<C> {
-    /// Converts a `surf::Request` to an `http_types::Request`.
-    fn into(self) -> http_types::Request {
+impl Into<http::Request> for Request {
+    /// Converts a `surf::Request` to an `http::Request`.
+    fn into(self) -> http::Request {
         self.req.unwrap()
     }
 }
 
-impl<C: HttpClient> fmt::Debug for Request<C> {
+impl fmt::Debug for Request {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(&self.req, f)
     }
 }
 
 #[cfg(any(feature = "native-client", feature = "h1-client"))]
-impl IntoIterator for Request<Client> {
+impl IntoIterator for Request {
     type Item = (HeaderName, HeaderValues);
     type IntoIter = headers::IntoIter;
 
@@ -683,7 +682,7 @@ impl IntoIterator for Request<Client> {
 }
 
 #[cfg(any(feature = "native-client", feature = "h1-client"))]
-impl<'a> IntoIterator for &'a Request<Client> {
+impl<'a> IntoIterator for &'a Request {
     type Item = (&'a HeaderName, &'a HeaderValues);
     type IntoIter = headers::Iter<'a>;
 
@@ -694,7 +693,7 @@ impl<'a> IntoIterator for &'a Request<Client> {
 }
 
 #[cfg(any(feature = "native-client", feature = "h1-client"))]
-impl<'a> IntoIterator for &'a mut Request<Client> {
+impl<'a> IntoIterator for &'a mut Request {
     type Item = (&'a HeaderName, &'a mut HeaderValues);
     type IntoIter = headers::IterMut<'a>;
 
@@ -704,7 +703,7 @@ impl<'a> IntoIterator for &'a mut Request<Client> {
     }
 }
 
-impl Index<HeaderName> for Request<Client> {
+impl Index<HeaderName> for Request {
     type Output = HeaderValues;
 
     /// Returns a reference to the value corresponding to the supplied name.
@@ -718,7 +717,7 @@ impl Index<HeaderName> for Request<Client> {
     }
 }
 
-impl Index<&str> for Request<Client> {
+impl Index<&str> for Request {
     type Output = HeaderValues;
 
     /// Returns a reference to the value corresponding to the supplied name.


### PR DESCRIPTION
This is a rebase of @islandusurper and @icewind1991's commits as linked in https://github.com/http-rs/surf/issues/69, based on an http-client branch which actually fixes the Sized and Error bounds issues on the `HttpClient` trait.

This makes `Client` no longer a generic, simplifying things as noted in https://github.com/http-rs/surf/issues/192 and also allowing things such as https://github.com/http-rs/surf/issues/150 (static client), while also fixing [other reported issues](https://github.com/http-rs/surf/issues/69#issuecomment-636366781).

Todo:
- [x] Merge https://github.com/http-rs/http-client/pull/31
- [x] Merge https://github.com/http-rs/http-client/pull/30
- [x] Merge https://github.com/http-rs/http-client/pull/29
- [x] http-client release
- [x] rebase/squash (remove git dep + always compiling commits(?))