### PR TITLE
Request, Response: inner types as_ref/mut

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -154,7 +154,7 @@ impl Request {
     /// let query = Index { page: 2 };
     /// let req = surf::get("https://httpbin.org/get").set_query(&query)?;
     /// assert_eq!(req.url().query(), Some("page=2"));
-    /// assert_eq!(req.request().unwrap().url().as_str(), "https://httpbin.org/get?page=2");
+    /// assert_eq!(req.as_ref().url().as_str(), "https://httpbin.org/get?page=2");
     /// # Ok(()) }
     /// ```
     pub fn set_query(
@@ -617,10 +617,17 @@ impl Request {
         let mut req = self.await?;
         Ok(req.body_form::<T>().await?)
     }
+}
 
-    /// Get the underlying HTTP request
-    pub fn request(&self) -> Option<&http_client::Request> {
-        self.req.as_ref()
+impl AsRef<http::Request> for Request {
+    fn as_ref(&self) -> &http::Request {
+        self.req.as_ref().unwrap()
+    }
+}
+
+impl AsMut<http::Request> for Request {
+    fn as_mut(&mut self) -> &mut http::Request {
+        self.req.as_mut().unwrap()
     }
 }
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,4 +1,5 @@
 use crate::http::{
+    self,
     headers::{self, HeaderName, HeaderValues, ToHeaderValues},
     Body, Error, Mime, StatusCode, Version,
 };
@@ -312,6 +313,18 @@ impl Response {
     /// ```
     pub async fn body_form<T: serde::de::DeserializeOwned>(&mut self) -> crate::Result<T> {
         self.res.body_form().await
+    }
+}
+
+impl AsRef<http::Response> for Response {
+    fn as_ref(&self) -> &http::Response {
+        &self.res
+    }
+}
+
+impl AsMut<http::Response> for Response {
+    fn as_mut(&mut self) -> &mut http::Response {
+        &mut self.res
     }
 }
 


### PR DESCRIPTION
Allows access to the underlying Request or Response by reference,
including mutably.

Mirrors Tide's api for this. (See https://github.com/http-rs/tide/commit/2024ed22f5e828974fd4f0806e7ffbeee8cae476)

This (mutable reference) will be necessary in order  to have
https://github.com/http-rs/surf/pull/195
on top of
https://github.com/http-rs/surf/pull/194
without adding another specialized public api for adjusting the url.

(semver-major due to removing `Request.request()` in favor of `Request.into::<http::Request>()`.)