### PR TITLE
Update examples, some docs

### DIFF
--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -1,14 +1,9 @@
-use async_std::task;
-
-// The need for Ok with turbofish is explained here
-// https://rust-lang.github.io/async-book/07_workarounds/03_err_in_async_blocks.html
-fn main() -> Result<(), http_types::Error> {
+#[async_std::main]
+async fn main() -> Result<(), http_types::Error> {
     femme::start(log::LevelFilter::Info)?;
 
-    task::block_on(async {
-        let uri = "https://httpbin.org/get";
-        let string: String = surf::get(uri).recv_string().await?;
-        println!("{}", string);
-        Ok::<(), http_types::Error>(())
-    })
+    let uri = "https://httpbin.org/get";
+    let string: String = surf::get(uri).recv_string().await?;
+    println!("{}", string);
+    Ok(())
 }

--- a/examples/middleware.rs
+++ b/examples/middleware.rs
@@ -1,4 +1,3 @@
-use async_std::task;
 use futures::future::BoxFuture;
 use std::sync::Arc;
 use surf::middleware::{HttpClient, Middleware, Next, Request, Response};
@@ -21,15 +20,12 @@ impl Middleware for Printer {
     }
 }
 
-// The need for Ok with turbofish is explained here
-// https://rust-lang.github.io/async-book/07_workarounds/03_err_in_async_blocks.html
-fn main() -> Result<(), http_types::Error> {
+#[async_std::main]
+async fn main() -> Result<(), http_types::Error> {
     femme::start(log::LevelFilter::Info)?;
 
-    task::block_on(async {
-        surf::get("https://httpbin.org/get")
-            .middleware(Printer {})
-            .await?;
-        Ok::<(), http_types::Error>(())
-    })
+    surf::get("https://httpbin.org/get")
+        .middleware(Printer {})
+        .await?;
+    Ok(())
 }

--- a/examples/next_reuse.rs
+++ b/examples/next_reuse.rs
@@ -1,4 +1,3 @@
-use async_std::task;
 use futures::future::BoxFuture;
 use futures::io::AsyncReadExt;
 use std::sync::Arc;
@@ -40,18 +39,16 @@ impl Middleware for Doubler {
     }
 }
 
-// The need for Ok with turbofish is explained here
-// https://rust-lang.github.io/async-book/07_workarounds/03_err_in_async_blocks.html
-fn main() -> Result<(), http_types::Error> {
-    femme::start(log::LevelFilter::Info).unwrap();
-    task::block_on(async {
-        let mut res = surf::get("https://httpbin.org/get")
-            .middleware(Doubler {})
-            .await?;
-        dbg!(&res);
-        let body = res.body_bytes().await?;
-        let body = String::from_utf8_lossy(&body);
-        println!("{}", body);
-        Ok::<(), http_types::Error>(())
-    })
+#[async_std::main]
+async fn main() -> Result<(), http_types::Error> {
+    femme::start(log::LevelFilter::Info)?;
+
+    let mut res = surf::get("https://httpbin.org/get")
+        .middleware(Doubler {})
+        .await?;
+    dbg!(&res);
+    let body = res.body_bytes().await?;
+    let body = String::from_utf8_lossy(&body);
+    println!("{}", body);
+    Ok(())
 }

--- a/examples/persistent.rs
+++ b/examples/persistent.rs
@@ -1,14 +1,10 @@
-use async_std::task;
+#[async_std::main]
+async fn main() -> Result<(), http_types::Error> {
+    femme::start(log::LevelFilter::Info)?;
 
-// The need for Ok with turbofish is explained here
-// https://rust-lang.github.io/async-book/07_workarounds/03_err_in_async_blocks.html
-fn main() -> Result<(), http_types::Error> {
-    femme::start(log::LevelFilter::Info).unwrap();
-    task::block_on(async {
-        let client = surf::Client::new();
-        let req1 = client.get("https://httpbin.org/get").recv_string();
-        let req2 = client.get("https://httpbin.org/get").recv_string();
-        futures::future::try_join(req1, req2).await?;
-        Ok::<(), http_types::Error>(())
-    })
+    let client = surf::Client::new();
+    let req1 = client.get("https://httpbin.org/get").recv_string();
+    let req2 = client.get("https://httpbin.org/get").recv_string();
+    futures::future::try_join(req1, req2).await?;
+    Ok(())
 }

--- a/examples/post.rs
+++ b/examples/post.rs
@@ -1,14 +1,10 @@
-use async_std::task;
+#[async_std::main]
+async fn main() -> Result<(), http_types::Error> {
+    femme::start(log::LevelFilter::Info)?;
 
-// The need for Ok with turbofish is explained here
-// https://rust-lang.github.io/async-book/07_workarounds/03_err_in_async_blocks.html
-fn main() -> Result<(), http_types::Error> {
-    femme::start(log::LevelFilter::Info).unwrap();
-    task::block_on(async {
-        let uri = "https://httpbin.org/post";
-        let data = serde_json::json!({ "name": "chashu" });
-        let res = surf::post(uri).body_json(&data).unwrap().await?;
-        assert_eq!(res.status(), http_types::StatusCode::Ok);
-        Ok::<(), http_types::Error>(())
-    })
+    let uri = "https://httpbin.org/post";
+    let data = serde_json::json!({ "name": "chashu" });
+    let res = surf::post(uri).body_json(&data).unwrap().await?;
+    assert_eq!(res.status(), http_types::StatusCode::Ok);
+    Ok(())
 }

--- a/src/middleware/logger/mod.rs
+++ b/src/middleware/logger/mod.rs
@@ -1,16 +1,6 @@
 //! Logging middleware.
 //!
-//! # Examples
-//!
-//! ```no_run
-//! # #[async_std::main]
-//! # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
-//! let mut res = surf::get("https://httpbin.org/get")
-//!     .middleware(surf::middleware::logger::new())
-//!     .await?;
-//! dbg!(res.body_string().await?);
-//! # Ok(()) }
-//! ```
+//! This middleware is used by default unless the `"middleware-logger"` feature is disabled.
 
 #[cfg(target_arch = "wasm32")]
 mod wasm;

--- a/src/request.rs
+++ b/src/request.rs
@@ -102,7 +102,7 @@ impl Request {
     /// # #[async_std::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     /// let res = surf::get("https://httpbin.org/get")
-    ///     .middleware(surf::middleware::logger::new())
+    ///     .middleware(surf::middleware::Redirect::default())
     ///     .await?;
     /// # Ok(()) }
     /// ```


### PR DESCRIPTION
- avoid showing `logger::new()`
- use `#[async_std::main]`
- do away with turbofish `Ok`