### PR TITLE
use async_trait to simplify async signatures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ encoding = ["encoding_rs", "web-sys"]
 
 [dependencies]
 futures = { version = "0.3.1", features = ["compat", "io-compat"] }
+futures-util = "0.3.5"
 log = { version = "0.4.7", features = ["kv_unstable"] }
 mime_guess = "2.0.3"
 serde = "1.0.97"
@@ -34,6 +35,7 @@ url = "2.0.0"
 http-client = "4.0.0"
 http-types = "2.0.0"
 async-std = { version = "1.6.0", default-features = false, features = ["std"] }
+async-trait = "0.1.36"
 pin-project-lite = "0.1.1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ middleware-logger = []
 encoding = ["encoding_rs", "web-sys"]
 
 [dependencies]
-futures = { version = "0.3.1", features = ["compat", "io-compat"] }
 futures-util = "0.3.5"
 log = { version = "0.4.7", features = ["kv_unstable"] }
 mime_guess = "2.0.3"

--- a/examples/middleware.rs
+++ b/examples/middleware.rs
@@ -1,22 +1,20 @@
-use futures::future::BoxFuture;
 use std::sync::Arc;
 use surf::middleware::{HttpClient, Middleware, Next, Request, Response};
 
 struct Printer;
 
+#[async_trait::async_trait]
 impl Middleware for Printer {
-    fn handle<'a>(
-        &'a self,
+    async fn handle(
+        &self,
         req: Request,
         client: Arc<dyn HttpClient>,
-        next: Next<'a>,
-    ) -> BoxFuture<'a, Result<Response, http_types::Error>> {
-        Box::pin(async move {
-            println!("sending a request!");
-            let res = next.run(req, client).await?;
-            println!("request completed!");
-            Ok(res)
-        })
+        next: Next<'_>,
+    ) -> Result<Response, http_types::Error> {
+        println!("sending a request!");
+        let res = next.run(req, client).await?;
+        println!("request completed!");
+        Ok(res)
     }
 }
 

--- a/examples/middleware.rs
+++ b/examples/middleware.rs
@@ -3,7 +3,7 @@ use surf::middleware::{HttpClient, Middleware, Next, Request, Response};
 
 struct Printer;
 
-#[async_trait::async_trait]
+#[surf::utils::async_trait]
 impl Middleware for Printer {
     async fn handle(
         &self,

--- a/examples/next_reuse.rs
+++ b/examples/next_reuse.rs
@@ -1,4 +1,4 @@
-use futures::io::AsyncReadExt;
+use futures_util::io::AsyncReadExt;
 use std::sync::Arc;
 use surf::middleware::{Body, HttpClient, Middleware, Next, Request, Response};
 
@@ -20,9 +20,11 @@ impl Middleware for Doubler {
             }
 
             let mut buf = Vec::new();
-            let (res1, res2) =
-                futures::future::join(next.run(req, client.clone()), next.run(new_req, client))
-                    .await;
+            let (res1, res2) = futures_util::future::join(
+                next.run(req, client.clone()),
+                next.run(new_req, client),
+            )
+            .await;
 
             let mut res = res1?;
             res.read_to_end(&mut buf).await?;

--- a/examples/next_reuse.rs
+++ b/examples/next_reuse.rs
@@ -4,7 +4,7 @@ use surf::middleware::{Body, HttpClient, Middleware, Next, Request, Response};
 
 struct Doubler;
 
-#[async_trait::async_trait]
+#[surf::utils::async_trait]
 impl Middleware for Doubler {
     async fn handle(
         &self,

--- a/examples/persistent.rs
+++ b/examples/persistent.rs
@@ -5,6 +5,6 @@ async fn main() -> Result<(), http_types::Error> {
     let client = surf::Client::new();
     let req1 = client.get("https://httpbin.org/get").recv_string();
     let req2 = client.get("https://httpbin.org/get").recv_string();
-    futures::future::try_join(req1, req2).await?;
+    futures_util::future::try_join(req1, req2).await?;
     Ok(())
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -22,7 +22,7 @@ use http_client::h1::H1Client;
 /// let client = surf::Client::new();
 /// let req1 = client.get("https://httpbin.org/get").recv_string();
 /// let req2 = client.get("https://httpbin.org/get").recv_string();
-/// let (str1, str2) = futures::future::try_join(req1, req2).await?;
+/// let (str1, str2) = futures_util::future::try_join(req1, req2).await?;
 /// # Ok(()) }
 /// ```
 pub struct Client {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,7 @@ mod request;
 mod response;
 
 pub mod middleware;
+pub mod utils;
 
 #[doc(inline)]
 pub use http_types::{self as http, Body, Error, Status, StatusCode};

--- a/src/middleware/logger/native.rs
+++ b/src/middleware/logger/native.rs
@@ -1,7 +1,6 @@
 use crate::middleware::{Middleware, Next, Request, Response};
 use http_client::HttpClient;
 
-use futures::future::BoxFuture;
 use std::fmt::Arguments;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -22,53 +21,52 @@ impl Logger {
     }
 }
 
+#[async_trait::async_trait]
 impl Middleware for Logger {
     #[allow(missing_doc_code_examples)]
-    fn handle<'a>(
-        &'a self,
+    async fn handle(
+        &self,
         req: Request,
         client: Arc<dyn HttpClient>,
-        next: Next<'a>,
-    ) -> BoxFuture<'a, Result<Response, http_types::Error>> {
-        Box::pin(async move {
-            let start_time = time::Instant::now();
-            let uri = format!("{}", req.url());
-            let method = format!("{}", req.method());
-            let id = COUNTER.fetch_add(1, Ordering::SeqCst);
-            print(
-                log::Level::Info,
-                format_args!("sending request"),
-                RequestPairs {
-                    id,
-                    uri: &uri,
-                    method: &method,
-                },
-            );
+        next: Next<'_>,
+    ) -> Result<Response, http_types::Error> {
+        let start_time = time::Instant::now();
+        let uri = format!("{}", req.url());
+        let method = format!("{}", req.method());
+        let id = COUNTER.fetch_add(1, Ordering::SeqCst);
+        print(
+            log::Level::Info,
+            format_args!("sending request"),
+            RequestPairs {
+                id,
+                uri: &uri,
+                method: &method,
+            },
+        );
 
-            let res = next.run(req, client).await?;
+        let res = next.run(req, client).await?;
 
-            let status = res.status();
-            let elapsed = start_time.elapsed();
-            let level = if status.is_server_error() {
-                log::Level::Error
-            } else if status.is_client_error() {
-                log::Level::Warn
-            } else {
-                log::Level::Info
-            };
+        let status = res.status();
+        let elapsed = start_time.elapsed();
+        let level = if status.is_server_error() {
+            log::Level::Error
+        } else if status.is_client_error() {
+            log::Level::Warn
+        } else {
+            log::Level::Info
+        };
 
-            print(
-                level,
-                format_args!("request completed"),
-                ResponsePairs {
-                    id,
-                    elapsed: &format!("{:?}", elapsed),
-                    status: status.into(),
-                },
-            );
+        print(
+            level,
+            format_args!("request completed"),
+            ResponsePairs {
+                id,
+                elapsed: &format!("{:?}", elapsed),
+                status: status.into(),
+            },
+        );
 
-            Ok(res)
-        })
+        Ok(res)
     }
 }
 

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -11,7 +11,7 @@
 //! #[derive(Debug)]
 //! pub struct Logger;
 //!
-//! #[async_trait::async_trait]
+//! #[surf::utils::async_trait]
 //! impl Middleware for Logger {
 //!     async fn handle(
 //!         &self,

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -31,7 +31,7 @@
 //! implementations.
 //!
 //! ```no_run
-//! use futures::future::BoxFuture;
+//! use futures_util::future::BoxFuture;
 //! use surf::middleware::{Next, Middleware, Request, Response, HttpClient};
 //! use std::time;
 //! use std::sync::Arc;

--- a/src/request.rs
+++ b/src/request.rs
@@ -6,7 +6,7 @@ use crate::http::{
 use crate::middleware::{Middleware, Next};
 use crate::Response;
 
-use futures::future::BoxFuture;
+use futures_util::future::BoxFuture;
 use http_client::{self, HttpClient};
 use serde::Serialize;
 use url::Url;

--- a/src/response.rs
+++ b/src/response.rs
@@ -5,7 +5,7 @@ use crate::http::{
 };
 
 use async_std::io::BufRead;
-use futures::prelude::*;
+use futures_util::io::AsyncRead;
 use serde::de::DeserializeOwned;
 
 use std::fmt;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,3 @@
+//! Miscellaneous utilities.
+
+pub use async_trait::async_trait;


### PR DESCRIPTION
Same as https://github.com/http-rs/tide/pull/639

> This change does not actually alter the output code, but hides the use of `Pin<Box<dyn Future<Output = T> + Send>>` behind [async_trait](https://docs.rs/async-trait/0.1.36/async_trait/index.html)

This simplifies middleware struct definitions. 

This also removes `futures` in favor of `futures_util`.