### PR TITLE
Client: rename .middleware to .with

### DIFF
--- a/examples/middleware.rs
+++ b/examples/middleware.rs
@@ -23,6 +23,6 @@ async fn main() -> Result<(), http_types::Error> {
     femme::start(log::LevelFilter::Info)?;
 
     let req = surf::get("https://httpbin.org/get");
-    surf::client().middleware(Printer {}).send(req).await?;
+    surf::client().with(Printer {}).send(req).await?;
     Ok(())
 }

--- a/examples/next_reuse.rs
+++ b/examples/next_reuse.rs
@@ -46,7 +46,7 @@ async fn main() -> Result<(), http_types::Error> {
     femme::start(log::LevelFilter::Info)?;
 
     let req = surf::get("https://httpbin.org/get");
-    let mut res = surf::client().middleware(Doubler {}).send(req).await?;
+    let mut res = surf::client().with(Doubler {}).send(req).await?;
     dbg!(&res);
     let body = res.body_bytes().await?;
     let body = String::from_utf8_lossy(&body);

--- a/src/client.rs
+++ b/src/client.rs
@@ -91,11 +91,11 @@ impl Client {
     /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     /// let req = surf::get("https://httpbin.org/get");
     /// let client = surf::client()
-    ///     .middleware(surf::middleware::Redirect::default());
+    ///     .with(surf::middleware::Redirect::default());
     /// let res = client.send(req).await?;
     /// # Ok(()) }
     /// ```
-    pub fn middleware(mut self, middleware: impl Middleware) -> Self {
+    pub fn with(mut self, middleware: impl Middleware) -> Self {
         let m = Arc::get_mut(&mut self.middleware)
             .expect("Registering middleware is not possible after the Client has been used");
         m.push(Arc::new(middleware));

--- a/src/middleware/logger/mod.rs
+++ b/src/middleware/logger/mod.rs
@@ -9,7 +9,7 @@
 //! # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
 //! let req = surf::get("https://httpbin.org/get");
 //! let mut res = surf::client()
-//!     .middleware(surf::middleware::Logger::new())
+//!     .with(surf::middleware::Logger::new())
 //!     .send(req).await?;
 //! dbg!(res.body_string().await?);
 //! # Ok(()) }

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -49,7 +49,7 @@
 //! #
 //! # #[async_std::main]
 //! # async fn main() -> Result<()> {
-//! #     surf::client().middleware(logger);
+//! #     surf::client().with(logger);
 //! #     Ok(())
 //! # }
 //! ```

--- a/src/middleware/redirect/mod.rs
+++ b/src/middleware/redirect/mod.rs
@@ -6,7 +6,7 @@
 //! # #[async_std::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
 //! let req = surf::get("https://httpbin.org/redirect/2");
-//! let client = surf::client().middleware(surf::middleware::Redirect::new(5));
+//! let client = surf::client().with(surf::middleware::Redirect::new(5));
 //! let mut res = client.send(req).await?;
 //! dbg!(res.body_string().await?);
 //! # Ok(()) }
@@ -62,7 +62,7 @@ impl Redirect {
     /// # #[async_std::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     /// let req = surf::get("https://httpbin.org/redirect/2");
-    /// let client = surf::client().middleware(surf::middleware::Redirect::new(5));
+    /// let client = surf::client().with(surf::middleware::Redirect::new(5));
     /// let mut res = client.send(req).await?;
     /// dbg!(res.body_string().await?);
     /// # Ok(()) }


### PR DESCRIPTION
API parity with Tide.

Closes #207

See that issue for more background.

Requires #194