### PR TITLE
Replace the native-client feature flags in client.rs and request.rs with its component features

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -7,7 +7,7 @@ use crate::{HttpClient, Request, RequestBuilder, Response, Result};
 
 use futures_util::future::BoxFuture;
 
-#[cfg(all(feature = "native-client", not(feature = "h1-client")))]
+#[cfg(all(any(feature = "curl-client", feature = "wasm-client"), not(feature = "h1-client")))]
 use http_client::native::NativeClient;
 
 #[cfg(feature = "h1-client")]
@@ -71,7 +71,7 @@ impl Client {
     /// # Ok(()) }
     /// ```
     pub fn new() -> Self {
-        #[cfg(all(feature = "native-client", not(feature = "h1-client")))]
+        #[cfg(all(any(feature = "curl-client", feature = "wasm-client"), not(feature = "h1-client")))]
         let client = NativeClient::new();
         #[cfg(feature = "h1-client")]
         let client = H1Client::new();

--- a/src/request.rs
+++ b/src/request.rs
@@ -20,7 +20,7 @@ pub struct Request {
     req: http_client::Request,
 }
 
-#[cfg(any(feature = "native-client", feature = "h1-client"))]
+#[cfg(any(feature = "curl-client", feature = "wasm-client", feature = "h1-client"))]
 impl Request {
     /// Create a new instance.
     ///
@@ -395,7 +395,7 @@ impl AsMut<http::Request> for Request {
     }
 }
 
-#[cfg(any(feature = "native-client", feature = "h1-client"))]
+#[cfg(any(feature = "curl-client", feature = "wasm-client", feature = "h1-client"))]
 impl From<http::Request> for Request {
     /// Converts an `http::Request` to a `surf::Request`.
     fn from(http_request: http::Request) -> Self {
@@ -420,7 +420,7 @@ impl fmt::Debug for Request {
     }
 }
 
-#[cfg(any(feature = "native-client", feature = "h1-client"))]
+#[cfg(any(feature = "curl-client", feature = "wasm-client", feature = "h1-client"))]
 impl IntoIterator for Request {
     type Item = (HeaderName, HeaderValues);
     type IntoIter = headers::IntoIter;
@@ -432,7 +432,7 @@ impl IntoIterator for Request {
     }
 }
 
-#[cfg(any(feature = "native-client", feature = "h1-client"))]
+#[cfg(any(feature = "curl-client", feature = "wasm-client", feature = "h1-client"))]
 impl<'a> IntoIterator for &'a Request {
     type Item = (&'a HeaderName, &'a HeaderValues);
     type IntoIter = headers::Iter<'a>;


### PR DESCRIPTION
Previously it was not possible to compile surf with just curl enabled.
This was caused by the usage of the native-client feature which by
default includes both curl and wasm backends. This change alters the
cfg options to gate on either wasm-client or curl-client.

NOTE: This doesn't completely fix compiling with just the curl feature, a separate PR will be opened on http-rs/http-client to finish the job.