### PR TITLE
add an optional base_url to Client

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -451,7 +451,9 @@ impl Client {
         RequestBuilder::new(Method::Patch, self.url(uri)).with_client(self.clone())
     }
 
-    /// sets the base path for this client
+    /// Sets the base URL for this client. All request URLs will be relative to this path.
+    ///
+    /// # Examples
     /// ```no_run
     /// # use http_types::Url;
     /// # fn main() -> http_types::Result<()> { async_std::task::block_on(async {


### PR DESCRIPTION
Encountered a need for this when trying to build a testing library for tide based on surf, but this seems like a generally useful thing when reusing a client.

I'm not sure if this is the right implementation, but it seemed like the least-invasive change to support this functionality

```rust
let mut client = surf::client();
client.set_base_url(Url::parse("http://example.com/api/v1")?);

let posts: Vec<Post> = client.get("/posts.json").recv_json().await?;
let users: Vec<User> = client.get("/users.json").recv_json().await?;
```

