### PR TITLE
src: feature flag each backend independently

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ h1-client = ["http-client/h1_client"]
 native-client = ["curl-client"]
 curl-client = ["http-client/curl_client"]
 wasm-client = ["http-client/wasm_client"]
+wasm_bindgen = ["wasm-client"]
 middleware-logger = []
 # requires web-sys for TextDecoder on wasm
 encoding = ["encoding_rs", "web-sys"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,8 @@ edition = "2018"
 # when the default feature set is updated, verify that the `--features` flags in
 # `.github/workflows/ci.yaml` are updated accordingly
 default = ["native-client", "middleware-logger", "encoding"]
-h1-client = ["wasm-client", "http-client/h1_client"]
-native-client = ["curl-client", "wasm-client", "http-client/native_client"]
+h1-client = ["http-client/h1_client"]
+native-client = ["curl-client"]
 curl-client = ["http-client/curl_client"]
 wasm-client = ["http-client/wasm_client"]
 middleware-logger = []

--- a/src/client.rs
+++ b/src/client.rs
@@ -19,9 +19,12 @@ use http_client::isahc::IsahcClient;
 ))]
 use http_client::h1::H1Client;
 
-#[cfg(all(
-    feature = "wasm-client",
-    not(any(feature = "h1-client", feature = "curl-client"))
+#[cfg(any(
+    all(
+        feature = "wasm-client",
+        not(any(feature = "h1-client", feature = "curl-client"))
+    ),
+    feature = "wasm_bindgen"
 ))]
 use http_client::wasm::WasmClient;
 
@@ -92,9 +95,12 @@ impl Client {
             not(any(feature = "curl-client", feature = "wasm-client"))
         ))]
         let client = H1Client::new();
-        #[cfg(all(
-            feature = "wasm-client",
-            not(any(feature = "h1-client", feature = "curl-client"))
+        #[cfg(any(
+            all(
+                feature = "wasm-client",
+                not(any(feature = "h1-client", feature = "curl-client"))
+            ),
+            feature = "wasm_bindgen"
         ))]
         let client = WasmClient::new();
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -8,13 +8,22 @@ use crate::{HttpClient, Request, RequestBuilder, Response, Result};
 use futures_util::future::BoxFuture;
 
 #[cfg(all(
-    any(feature = "curl-client", feature = "wasm-client"),
-    not(feature = "h1-client")
+    feature = "curl-client",
+    not(any(feature = "h1-client", feature = "wasm-client"))
 ))]
-use http_client::native::NativeClient;
+use http_client::isahc::IsahcClient;
 
-#[cfg(feature = "h1-client")]
+#[cfg(all(
+    feature = "h1-client",
+    not(any(feature = "curl-client", feature = "wasm-client"))
+))]
 use http_client::h1::H1Client;
+
+#[cfg(all(
+    feature = "wasm-client",
+    not(any(feature = "h1-client", feature = "curl-client"))
+))]
+use http_client::wasm::WasmClient;
 
 /// An HTTP client, capable of sending `Request`s and running a middleware stack.
 ///
@@ -74,12 +83,21 @@ impl Client {
     /// ```
     pub fn new() -> Self {
         #[cfg(all(
-            any(feature = "curl-client", feature = "wasm-client"),
-            not(feature = "h1-client")
+            feature = "curl-client",
+            not(any(feature = "h1-client", feature = "wasm-client"))
         ))]
-        let client = NativeClient::new();
-        #[cfg(feature = "h1-client")]
+        let client = IsahcClient::new();
+        #[cfg(all(
+            feature = "h1-client",
+            not(any(feature = "curl-client", feature = "wasm-client"))
+        ))]
         let client = H1Client::new();
+        #[cfg(all(
+            feature = "wasm-client",
+            not(any(feature = "h1-client", feature = "curl-client"))
+        ))]
+        let client = WasmClient::new();
+
         Self::with_http_client(Arc::new(client))
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,8 +63,8 @@
 //!
 //! # Features
 //! The following features are available.
-//! - __`h1-client`:__ use `async-h1` on the server and `window.fetch` in the browser.
-//! - __`native-client` (default):__ use `curl` on the server and `window.fetch` in the browser.
+//! - __`h1-client`:__ use `async-h1`as the HTTP backend.
+//! - __`native-client` (default):__ same as `curl-client`.
 //! - __`middleware-logger` (default):__ enables logging requests and responses using a middleware.
 //! - __`curl-client`:__ use `curl` (through `isahc`) as the HTTP backend.
 //! - __`wasm-client`:__ use `window.fetch` as the HTTP backend.
@@ -76,6 +76,13 @@
 #![cfg_attr(test, deny(warnings))]
 #![doc(html_favicon_url = "https://yoshuawuyts.com/assets/http-rs/favicon.ico")]
 #![doc(html_logo_url = "https://yoshuawuyts.com/assets/http-rs/logo-rounded.png")]
+
+#[cfg(not(any(
+    feature = "h1-client",
+    feature = "curl-client",
+    feature = "wasm-client"
+)))]
+compile_error!("A client backend must be set via surf features. Choose one: \"h1-client\", \"curl-client\", \"wasm-client\".");
 
 mod client;
 mod request;


### PR DESCRIPTION
No longer has a magic wasm default, wasm must be specified independently.

Opens room for per-backend optimization (such as Isahc singleton).