### PR TITLE
RequestBuilder: use shared client internally if available

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ edition = "2018"
 default = ["native-client", "middleware-logger", "encoding"]
 h1-client = ["http-client/h1_client"]
 native-client = ["curl-client"]
-curl-client = ["http-client/curl_client"]
+curl-client = ["http-client/curl_client", "once_cell"]
 wasm-client = ["http-client/wasm_client"]
 wasm_bindgen = ["wasm-client"]
 middleware-logger = []
@@ -42,6 +42,7 @@ http-types = "2.0.0"
 async-std = { version = "1.6.0", default-features = false, features = ["std"] }
 async-trait = "0.1.36"
 pin-project-lite = "0.1.1"
+once_cell = { version = "1.4.1", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 # encoding

--- a/src/request_builder.rs
+++ b/src/request_builder.rs
@@ -228,7 +228,7 @@ impl RequestBuilder {
         if let Some(client) = self.client {
             client.send(self.req.unwrap()) // Ownership nonsense, same as `build()`.
         } else {
-            let client = Client::new();
+            let client = Client::new_shared();
             client.send(self.build())
         }
     }
@@ -250,7 +250,7 @@ impl Future for RequestBuilder {
             if let Some(client) = &self.client {
                 self.fut = Some(client.send(req))
             } else {
-                let client = Client::new();
+                let client = Client::new_shared();
                 self.fut = Some(client.send(req))
             }
         }


### PR DESCRIPTION
This should help reduce overhead from creating new Isahc clients.

See https://docs.rs/isahc/0.9.8/isahc/struct.HttpClient.html

From Isahc's Docs:
> The client maintains a connection pool internally and is not cheap to create ...

This may be possible without https://github.com/http-rs/surf/pull/230 but was much easier to do with those config feature changes.