### PR TITLE
feature changes for wasm support on 2.x

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
   push:
     branches:
+      - main
       - staging
       - trying
 
@@ -18,7 +19,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         rust: [nightly]
-        backend: [native-client, h1-client]
+        backend: [curl-client, h1-client]
 
     steps:
     - uses: actions/checkout@master
@@ -33,12 +34,6 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: check
-        args: --all --bins --examples
-
-    - name: check unstable
-      uses: actions-rs/cargo@v1
-      with:
-        command:  check
         args: --all --benches --bins --examples --tests
 
     - name: tests
@@ -46,6 +41,32 @@ jobs:
       with:
         command: test
         args: --all --no-default-features --features '${{ matrix.backend }} middleware-logger encoding'
+
+  check_wasm:
+    name: Check wasm targets
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@master
+
+    - name: Install nightly with wasm32-unknown-unknown
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly
+        target: wasm32-unknown-unknown
+        override: true
+
+    - name: check
+      uses: actions-rs/cargo@v1
+      with:
+        command: check
+        args: --target wasm32-unknown-unknown --no-default-features --features wasm-client
+
+    - name: check with middleware and encoding
+      uses: actions-rs/cargo@v1
+      with:
+        command: check
+        args: --target wasm32-unknown-unknown --no-default-features --features wasm-client,middleware-logger,encoding
 
   check_fmt_and_docs:
     name: Checking fmt, clippy, and docs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,8 @@ edition = "2018"
 [features]
 # when the default feature set is updated, verify that the `--features` flags in
 # `.github/workflows/ci.yaml` are updated accordingly
-default = ["native-client", "middleware-logger", "encoding"]
+default = ["curl-client", "middleware-logger", "encoding"]
 h1-client = ["http-client/h1_client"]
-native-client = ["curl-client"]
 curl-client = ["http-client/curl_client", "once_cell"]
 wasm-client = ["http-client/wasm_client"]
 wasm_bindgen = ["wasm-client"]
@@ -30,14 +29,14 @@ middleware-logger = []
 encoding = ["encoding_rs", "web-sys"]
 
 [dependencies]
-futures-util = "0.3.5"
+futures-util = { version = "0.3.5", features = ["io"] }
 log = { version = "0.4.7", features = ["kv_unstable"] }
 mime_guess = "2.0.3"
 serde = "1.0.97"
 serde_json = "1.0.40"
 serde_urlencoded = "0.6.1"
 url = "2.0.0"
-http-client = "4.0.0"
+http-client = { version = "5.0.0", default-features = false }
 http-types = "2.0.0"
 async-std = { version = "1.6.0", default-features = false, features = ["std"] }
 async-trait = "0.1.36"

--- a/src/client.rs
+++ b/src/client.rs
@@ -125,7 +125,7 @@ impl Client {
     /// ```rust
     /// # #[cfg(feature = "curl-client")] {
     /// # use std::sync::Arc;
-    /// # use http_client::isahc::IsahcClient;
+    /// use http_client::isahc::IsahcClient;
     /// let client = surf::Client::with_http_client(Arc::new(IsahcClient::new()));
     /// # }
     /// ```

--- a/src/client.rs
+++ b/src/client.rs
@@ -123,9 +123,11 @@ impl Client {
     /// # Examples
     ///
     /// ```rust
+    /// # #[cfg(feature = "curl-client")] {
     /// # use std::sync::Arc;
-    /// # use http_client::h1::H1Client;
-    /// let client = surf::Client::with_http_client(Arc::new(H1Client::new()));
+    /// # use http_client::isahc::IsahcClient;
+    /// let client = surf::Client::with_http_client(Arc::new(IsahcClient::new()));
+    /// # }
     /// ```
 
     pub fn with_http_client(http_client: Arc<dyn HttpClient>) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,12 +62,13 @@
 //! ```
 //!
 //! # Features
-//! The following features are available.
-//! - __`h1-client`:__ use `async-h1`as the HTTP backend.
-//! - __`native-client` (default):__ same as `curl-client`.
-//! - __`middleware-logger` (default):__ enables logging requests and responses using a middleware.
-//! - __`curl-client`:__ use `curl` (through `isahc`) as the HTTP backend.
+//! The following features are available. The default features are
+//! `curl-client`, `middleware-logger`, and `encoding`
+//! - __`h1-client`:__ use `async-h1` as the HTTP backend.
+//! - __`curl-client` (default):__ use `curl` (through `isahc`) as the HTTP backend.
 //! - __`wasm-client`:__ use `window.fetch` as the HTTP backend.
+//! - __`middleware-logger` (default):__ enables logging requests and responses using a middleware.
+//! - __`encoding` (default):__ enables support for body encodings other than utf-8
 
 #![forbid(rust_2018_idioms)]
 #![deny(missing_debug_implementations, nonstandard_style)]

--- a/src/middleware/logger/native.rs
+++ b/src/middleware/logger/native.rs
@@ -32,7 +32,7 @@ impl Middleware for Logger {
         let start_time = time::Instant::now();
         let uri = format!("{}", req.url());
         let method = format!("{}", req.method());
-        let id = COUNTER.fetch_add(1, Ordering::SeqCst);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
         print(
             log::Level::Info,
             format_args!("sending request"),

--- a/src/middleware/logger/wasm.rs
+++ b/src/middleware/logger/wasm.rs
@@ -1,8 +1,5 @@
-use crate::middleware::{Middleware, Next, Request, Response};
-use http_client::HttpClient;
-
+use crate::middleware::{Client, Middleware, Next, Request, Response};
 use std::fmt::Arguments;
-use std::sync::Arc;
 
 /// Log each request's duration.
 #[derive(Debug)]
@@ -23,10 +20,10 @@ impl Middleware for Logger {
     async fn handle(
         &self,
         req: Request,
-        client: Arc<dyn HttpClient>,
+        client: Client,
         next: Next<'_>,
     ) -> Result<Response, http_types::Error> {
-        let uri = format!("{}", req.uri());
+        let uri = format!("{}", req.url());
         let method = format!("{}", req.method());
         print(
             log::Level::Info,
@@ -52,7 +49,7 @@ impl Middleware for Logger {
             level,
             format_args!("request completed"),
             ResponsePairs {
-                status: status.as_u16(),
+                status: status.into(),
             },
         );
         Ok(res)

--- a/src/request.rs
+++ b/src/request.rs
@@ -9,9 +9,7 @@ use serde::Serialize;
 use url::Url;
 
 use std::fmt;
-use std::io;
 use std::ops::Index;
-use std::path::Path;
 
 /// An HTTP request, returns a `Response`.
 #[derive(Clone)]
@@ -367,7 +365,8 @@ impl Request {
     /// # Errors
     ///
     /// This method will return an error if the file couldn't be read.
-    pub async fn body_file(&mut self, path: impl AsRef<Path>) -> io::Result<()> {
+    #[cfg(not(target_arch = "wasm32"))]
+    pub async fn body_file(&mut self, path: impl AsRef<std::path::Path>) -> std::io::Result<()> {
         self.set_body(Body::from_file(path).await?);
         Ok(())
     }


### PR DESCRIPTION
this pr does three things:
* updates http-client to 5.0.0
* removes the native-client feature. since using the wasm client requires explicitly specifying a feature for that, the notion of "native-client" isn't relevant anymore. it existed as a magical "no features needed, works across platforms."
* loads no default features on http-client. without this, surf does not build on wasm. otherwise we build "wasm and also the default features," which currently means h1-client with tls, which won't build on wasm.
* adds a wasm check for ci
* fixes wasm build
* fixes h1 client build
