### PR TITLE
crate: add hyper-client feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,9 @@ edition = "2018"
 # when the default feature set is updated, verify that the `--features` flags in
 # `.github/workflows/ci.yaml` are updated accordingly
 default = ["curl-client", "middleware-logger", "encoding"]
-h1-client = ["http-client/h1_client", "default-client"]
 curl-client = ["http-client/curl_client", "once_cell", "default-client"]
+h1-client = ["http-client/h1_client", "default-client"]
+hyper-client = ["http-client/hyper_client", "once_cell", "default-client", "async-std/tokio02"]
 wasm-client = ["http-client/wasm_client", "default-client"]
 default-client = []
 middleware-logger = []
@@ -34,7 +35,7 @@ log = { version = "0.4.7", features = ["kv_unstable"] }
 mime_guess = "2.0.3"
 serde = "1.0.97"
 serde_json = "1.0.40"
-http-client = { version = "6.0.0", default-features = false }
+http-client = { version = "6.1.0", default-features = false }
 http-types = "2.5.0"
 async-std = { version = "1.6.0", default-features = false, features = ["std"] }
 async-trait = "0.1.36"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,8 +64,9 @@
 //! # Features
 //! The following features are available. The default features are
 //! `curl-client`, `middleware-logger`, and `encoding`
-//! - __`h1-client`:__ use `async-h1` as the HTTP backend.
 //! - __`curl-client` (default):__ use `curl` (through `isahc`) as the HTTP backend.
+//! - __`h1-client`:__ use `async-h1` as the HTTP backend.
+//! - __`hyper-client`:__ use `hyper` (hyper.rs) as the HTTP backend.
 //! - __`wasm-client`:__ use `window.fetch` as the HTTP backend.
 //! - __`middleware-logger` (default):__ enables logging requests and responses using a middleware.
 //! - __`encoding` (default):__ enables support for body encodings other than utf-8


### PR DESCRIPTION
Adds support for `http-client/hyper_client`,  including global pooling for one-off surf methods.

Also adjusts client configuration to fallback once again, starting with the highest specificity (wasm) and allowing e.g. `features = ["hyper-client"]` to override the default.