### PR TITLE
remove wasm_bindgen feature (retain wasm-client, which is identical in practice)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ default = ["curl-client", "middleware-logger", "encoding"]
 h1-client = ["http-client/h1_client"]
 curl-client = ["http-client/curl_client", "once_cell"]
 wasm-client = ["http-client/wasm_client"]
-wasm_bindgen = ["wasm-client"]
 middleware-logger = []
 # requires web-sys for TextDecoder on wasm
 encoding = ["encoding_rs", "web-sys"]

--- a/wasm-test/Cargo.toml
+++ b/wasm-test/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-surf = {path = "..", default-features = false, features = ["wasm-client"]}
+surf = { path = "..", default-features = false, features = ["wasm-client"] }
 wasm-bindgen-test = "0.3.18"
 async-std = "1.6.4"
 serde_json = "1.0.57"


### PR DESCRIPTION
As mentioned in the review of #233, I think the wasm_bindgen feature was not the right path for surf, as a library crate. It is only added by wasm_pack to the top level crate, which isn't relevant to a library crate, so users will still need to explicitly specify a wasm feature. As long as we require specifying a wasm feature, we should: a) only have one wasm flag, instead of two identical flags, and b) use a flag that is descriptive (wasm-client matches with h1-client and curl-client)