### PR TITLE
Allow surf to build without a default client

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,6 +36,12 @@ jobs:
         command: check
         args: --examples
 
+    - name: check no features
+      uses: actions-rs/cargo@v1
+      with:
+        command: check
+        args: --no-default-features
+
     - name: tests
       uses: actions-rs/cargo@v1
       with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,10 @@ edition = "2018"
 # when the default feature set is updated, verify that the `--features` flags in
 # `.github/workflows/ci.yaml` are updated accordingly
 default = ["curl-client", "middleware-logger", "encoding"]
-h1-client = ["http-client/h1_client"]
-curl-client = ["http-client/curl_client", "once_cell"]
-wasm-client = ["http-client/wasm_client"]
+h1-client = ["http-client/h1_client", "default-client"]
+curl-client = ["http-client/curl_client", "once_cell", "default-client"]
+wasm-client = ["http-client/wasm_client", "default-client"]
+default-client = []
 middleware-logger = []
 # requires web-sys for TextDecoder on wasm
 encoding = ["encoding_rs", "web-sys"]
@@ -41,6 +42,7 @@ async-std = { version = "1.6.0", default-features = false, features = ["std"] }
 async-trait = "0.1.36"
 pin-project-lite = "0.1.1"
 once_cell = { version = "1.4.1", optional = true }
+cfg-if = "0.1.10"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 # encoding

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,13 +78,6 @@
 #![doc(html_favicon_url = "https://yoshuawuyts.com/assets/http-rs/favicon.ico")]
 #![doc(html_logo_url = "https://yoshuawuyts.com/assets/http-rs/logo-rounded.png")]
 
-#[cfg(not(any(
-    feature = "h1-client",
-    feature = "curl-client",
-    feature = "wasm-client"
-)))]
-compile_error!("A client backend must be set via surf features. Choose one: \"h1-client\", \"curl-client\", \"wasm-client\".");
-
 mod client;
 mod request;
 mod request_builder;
@@ -106,22 +99,15 @@ pub use request::Request;
 pub use request_builder::RequestBuilder;
 pub use response::{DecodeError, Response};
 
-#[cfg(any(
-    feature = "curl-client",
-    feature = "wasm-client",
-    feature = "h1-client"
-))]
-mod one_off;
-#[cfg(any(
-    feature = "curl-client",
-    feature = "wasm-client",
-    feature = "h1-client"
-))]
-pub use one_off::{connect, delete, get, head, options, patch, post, put, trace};
-
-/// Construct a new `Client`.
-pub fn client() -> Client {
-    Client::new()
+cfg_if::cfg_if! {
+    if #[cfg(feature = "default-client")] {
+        mod one_off;
+        pub use one_off::{connect, delete, get, head, options, patch, post, put, trace};
+        /// Construct a new `Client`.
+        pub fn client() -> Client {
+            Client::new()
+        }
+    }
 }
 
 /// A specialized Result type for Surf.

--- a/src/middleware/logger/mod.rs
+++ b/src/middleware/logger/mod.rs
@@ -15,14 +15,12 @@
 //! # Ok(()) }
 //! ```
 
-#[cfg(target_arch = "wasm32")]
-mod wasm;
-
-#[cfg(target_arch = "wasm32")]
-pub use wasm::Logger;
-
-#[cfg(not(target_arch = "wasm32"))]
-mod native;
-
-#[cfg(not(target_arch = "wasm32"))]
-pub use native::Logger;
+cfg_if::cfg_if! {
+    if #[cfg(target_arch = "wasm32")] {
+        mod wasm;
+        pub use wasm::Logger;
+    } else {
+        mod native;
+        pub use native::Logger;
+    }
+}

--- a/src/request.rs
+++ b/src/request.rs
@@ -18,11 +18,6 @@ pub struct Request {
     req: http_client::Request,
 }
 
-#[cfg(any(
-    feature = "curl-client",
-    feature = "wasm-client",
-    feature = "h1-client"
-))]
 impl Request {
     /// Create a new instance.
     ///
@@ -418,11 +413,6 @@ impl fmt::Debug for Request {
     }
 }
 
-#[cfg(any(
-    feature = "curl-client",
-    feature = "wasm-client",
-    feature = "h1-client"
-))]
 impl IntoIterator for Request {
     type Item = (HeaderName, HeaderValues);
     type IntoIter = headers::IntoIter;
@@ -434,11 +424,6 @@ impl IntoIterator for Request {
     }
 }
 
-#[cfg(any(
-    feature = "curl-client",
-    feature = "wasm-client",
-    feature = "h1-client"
-))]
 impl<'a> IntoIterator for &'a Request {
     type Item = (&'a HeaderName, &'a HeaderValues);
     type IntoIter = headers::Iter<'a>;
@@ -449,11 +434,6 @@ impl<'a> IntoIterator for &'a Request {
     }
 }
 
-#[cfg(any(
-    feature = "wasm-client",
-    feature = "curl-client",
-    feature = "h1-client"
-))]
 impl<'a> IntoIterator for &'a mut Request {
     type Item = (&'a HeaderName, &'a mut HeaderValues);
     type IntoIter = headers::IterMut<'a>;


### PR DESCRIPTION
This PR:
* ensures that surf can build as much as possible without an enabled client.  This is important in use cases where someone is providing their own HttpClient backend, as supported by surf features.
* simplifies the logic for checking if there's a client by adding a "default-client" feature that's enabled by all of the other clients.  This will simplify addition of future client backends.
* introduces the use of cfg_if, in order to make the mutually-exclusive conditional logic more clear.

Not covered by this PR: Considering what happens if someone enables _multiple_ backends.

There are exactly two places that panic in this PR that would not have panicked otherwise.  We could return a custom error if that's preferred, although it seems like "trying to send a request without a default client backend and without an explicitly configured http_client" is exactly the sort of developer-caused error scenario that panics are ideal for. This also should be a fairly rare condition, because anyone using surf without default features likely understands that they can't rely on a default client.