### PR TITLE
client: make global client work with non-Clone HttpClient

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,9 @@ edition = "2018"
 # when the default feature set is updated, verify that the `--features` flags in
 # `.github/workflows/ci.yaml` are updated accordingly
 default = ["curl-client", "middleware-logger", "encoding"]
-h1-client = ["http-client/h1_client", "default-client"]
 curl-client = ["http-client/curl_client", "once_cell", "default-client"]
+h1-client = ["http-client/h1_client", "default-client"]
+hyper-client = ["http-client/hyper_client", "once_cell", "default-client", "async-std/tokio02"]
 wasm-client = ["http-client/wasm_client", "default-client"]
 default-client = []
 middleware-logger = []
@@ -36,7 +37,7 @@ serde = "1.0.97"
 serde_json = "1.0.40"
 serde_urlencoded = "0.6.1"
 url = "2.0.0"
-http-client = { version = "5.0.0", default-features = false }
+http-client = { git = "https://github.com/Fishrock123/http-client.git", branch = "hyper-improvements", default-features = false }
 http-types = "2.0.0"
 async-std = { version = "1.6.0", default-features = false, features = ["std"] }
 async-trait = "0.1.36"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ serde = "1.0.97"
 serde_json = "1.0.40"
 serde_urlencoded = "0.6.1"
 url = "2.0.0"
-http-client = { git = "https://github.com/Fishrock123/http-client.git", branch = "hyper-improvements", default-features = false }
+http-client = { git = "https://github.com/Fishrock123/http-client.git", branch = "no-clone", default-features = false }
 http-types = "2.0.0"
 async-std = { version = "1.6.0", default-features = false, features = ["std"] }
 async-trait = "0.1.36"

--- a/src/client.rs
+++ b/src/client.rs
@@ -22,7 +22,7 @@ cfg_if! {
 cfg_if! {
     if #[cfg(any(feature = "curl-client", feature = "hyper-client"))] {
         use once_cell::sync::Lazy;
-        static GLOBAL_CLIENT: Lazy<DefaultClient> = Lazy::new(DefaultClient::new);
+        static GLOBAL_CLIENT: Lazy<Arc<DefaultClient>> = Lazy::new(|| Arc::new(DefaultClient::new()));
     }
 }
 
@@ -127,7 +127,7 @@ impl Client {
     pub(crate) fn new_shared() -> Self {
         cfg_if! {
             if #[cfg(any(feature = "curl-client", feature = "hyper-client"))] {
-                Self::with_http_client(Arc::new(GLOBAL_CLIENT.clone()))
+                Self::with_http_client(GLOBAL_CLIENT.clone())
             } else {
                 Self::new()
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,8 +64,9 @@
 //! # Features
 //! The following features are available. The default features are
 //! `curl-client`, `middleware-logger`, and `encoding`
-//! - __`h1-client`:__ use `async-h1` as the HTTP backend.
 //! - __`curl-client` (default):__ use `curl` (through `isahc`) as the HTTP backend.
+//! - __`h1-client`:__ use `async-h1` as the HTTP backend.
+//! - __`hyper-client`:__ use `hyper` (hyper.rs) as the HTTP backend.
 //! - __`wasm-client`:__ use `window.fetch` as the HTTP backend.
 //! - __`middleware-logger` (default):__ enables logging requests and responses using a middleware.
 //! - __`encoding` (default):__ enables support for body encodings other than utf-8


### PR DESCRIPTION
This is mostly required by the hyper client, so this is based on https://github.com/http-rs/surf/pull/234 for future simplicity. https://github.com/http-rs/surf/pull/238 will also create some conflicts here but they shouldn't be too difficult to solve.