### PR TITLE
deps, client: update for HttpClient 6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ serde = "1.0.97"
 serde_json = "1.0.40"
 serde_urlencoded = "0.6.1"
 url = "2.0.0"
-http-client = { version = "5.0.0", default-features = false }
+http-client = { version = "6.0.0", default-features = false }
 http-types = "2.0.0"
 async-std = { version = "1.6.0", default-features = false, features = ["std"] }
 async-trait = "0.1.36"

--- a/src/client.rs
+++ b/src/client.rs
@@ -12,8 +12,7 @@ cfg_if! {
     if #[cfg(feature = "curl-client")] {
         use http_client::isahc::IsahcClient as DefaultClient;
         use once_cell::sync::Lazy;
-        static GLOBAL_CLIENT: Lazy<http_client::isahc::IsahcClient> =
-            Lazy::new(http_client::isahc::IsahcClient::new);
+        static GLOBAL_CLIENT: Lazy<Arc<DefaultClient>> = Lazy::new(|| Arc::new(DefaultClient::new()));
     } else if #[cfg(feature = "wasm-client")] {
         use http_client::wasm::WasmClient as DefaultClient;
     } else if #[cfg(feature = "h1-client")] {
@@ -125,7 +124,7 @@ impl Client {
     pub(crate) fn new_shared() -> Self {
         cfg_if! {
             if #[cfg(feature = "curl-client")] {
-                Self::with_http_client(GLOBAL_CLIENT.clone())
+                Self::with_http_client_internal(GLOBAL_CLIENT.clone())
             } else {
                 Self::new()
             }


### PR DESCRIPTION
All of the global shared client now uses just one Arc.

Refs: https://github.com/http-rs/http-client/pull/48