### PR TITLE
2.0.0-alpha.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,14 +63,14 @@ let req = surf::post(url) // Now returns a `surf::RequestBuilder`!
 let res = client.send(req).await?;
 ```
 
-# Additions
+### Additions
 - `surf::Request` added many methods that exist in `tide::Request`.
 - `surf::Response` added many methods that exist in `tide::Response`.
 - `surf::http`, an export of `http_types`, similar to `tide::http`.
 - `surf::middleware::Redirect`, a middleware to handle redirect status codes.
 - All conversions for `Request` and `Response` between `http_types` and `surf` now exist.
 
-# Changes
+### Changes
 - `surf::Request` changed many methods to be like those in `tide::Request`.
 - `surf::Response` changed many methods to be like those in `tide::Response`.
 - Surf now uses `http-types::mime` instead of the `mime` crate.
@@ -85,12 +85,12 @@ let res = client.send(req).await?;
   - Then, send the request from that client via `client.send()` e.g. `let res = client.send(request).await?;`.
 - `surf::Client` now can set a "base url" for that client via `client.set_base_url()`.
 
-# Fixes
+### Fixes
 - `From<http_types::Request> for Request` now properly propagates all properties.
 - A cloned `surf::Client` no longer adds middleware onto its ancestor's middleware stack.
 - Some feature flags are now correct.
 
-# Internal
+### Internal
 - Use Clippy in CI.
 - Improved examples.
 - Now only depends on `futures_util` rather than all of `futures`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://book.async.rs/overview
 
 ## [Unreleased]
 
+## [2.0.0-alpha.6] - 2020-09-27
+
+This is an alpha release in preparation of 2.0.0, so you can start using Surf with stable futures. The aim is for this to be the last 2.0 alpha release.
+
+As of this release, `surf::get()`, `surf::post()`, etc, now use a globally shared client internally, allowing for easier access to optimizations such as connection pooling.
+
+### Removals
+- Removed `native-client` feature flag in favor of direct `curl-client` default.
+
+### Changes
+- `wasm-client` feature is no longer automatic and must be set via cargo features.
+- All client feature flags are now mutually exclusive. `curl-client` is the default.
+- `surf::method_name` "one-off" methods now use a shared client internally if the client is `curl-client`. (Default)
+- `Client::with_http_client()` is now generic for any `HttpClient` rather than taking an `Arc<dyn HttpClient>`.
+  - (The http client is still stored internally as a dynamic pointer.)
+- `HttpClient` has been upgraded to 6.0, removing `Clone` from the built in client backends.
+
+### Fixes
+- Surf can once again build with `--no-default-features` (and no client).
+- Doc updates
+
+### Internal
+- `wasm-client` now has proper headless browser CI testing.
+
 ## [2.0.0-alpha.5] - 2020-09-07
 
 This is an alpha release in preparation of 2.0.0, so you can start using Surf with stable futures. There may be significant breaking changes before the final 2.0 release. Until thin, we recommend pinning to the particular alpha:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "surf"
-version = "2.0.0-alpha.5"
+version = "2.0.0-alpha.6"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/http-rs/surf"
 documentation = "https://docs.rs/surf"


### PR DESCRIPTION
Awaiting #226 and #240:

> This is an alpha release in preparation of 2.0.0, so you can start using Surf with stable futures. The aim is for this to be the last 2.0 alpha release.
> 
> As of this release, `surf::get()`, `surf::post()`, etc, now use a globally shared client internally, allowing for easier access to optimizations such as connection pooling.
> 
> ### Removals
> - Removed `native-client` feature flag in favor of direct `curl-client` default.
> 
> ### Changes
> - `wasm-client` feature is no longer automatic and must be set via cargo features.
> - All client feature flags are now mutually exclusive. `curl-client` is the default.
> - `surf::method_name` "one-off" methods now use a shared client internally if the client is `curl-client`. (Default)
> - `Client::with_http_client()` is now generic for any `HttpClient` rather than taking an `Arc<dyn HttpClient>`.
>   - (The http client is still stored internally as a dynamic pointer.)
> - `HttpClient` has been upgraded to 6.0, removing `Clone` from the built in client backends.
> 
> ### Fixes
> - Surf can once again build with `--no-default-features` (and no client).
> - Doc updates
> 
> ### Internal
> - `wasm-client` now has proper headless browser CI testing.