### PR TITLE
remove url crate re-export

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,12 +87,10 @@ pub mod middleware;
 pub mod utils;
 
 #[doc(inline)]
-pub use http_types::{self as http, Body, Error, Status, StatusCode};
+pub use http_types::{self as http, Body, Error, Status, StatusCode, Url};
 
 #[doc(inline)]
 pub use http_client::HttpClient;
-
-pub use url;
 
 pub use client::Client;
 pub use request::Request;

--- a/src/middleware/redirect/mod.rs
+++ b/src/middleware/redirect/mod.rs
@@ -12,9 +12,8 @@
 //! # Ok(()) }
 //! ```
 
-use crate::http::{headers, StatusCode};
+use crate::http::{headers, StatusCode, Url};
 use crate::middleware::{Middleware, Next, Request, Response};
-use crate::url::Url;
 use crate::{Client, Result};
 
 // List of acceptible 300-series redirect codes.

--- a/src/request.rs
+++ b/src/request.rs
@@ -31,7 +31,7 @@ impl Request {
     /// # #[async_std::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     /// use surf::http::Method;
-    /// use surf::url::Url;
+    /// use surf::Url;
     ///
     /// let method = Method::Get;
     /// let url = Url::parse("https://httpbin.org/get")?;
@@ -47,7 +47,7 @@ impl Request {
     ///
     /// # Example:
     /// ```rust
-    /// # use surf::url::Url;
+    /// # use surf::Url;
     /// # use surf::{http, Request};
     /// # #[async_std::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
@@ -248,7 +248,7 @@ impl Request {
     /// ```no_run
     /// # #[async_std::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
-    /// use surf::url::Url;
+    /// use surf::Url;
     /// let req = surf::get("https://httpbin.org/get").build();
     /// assert_eq!(req.url(), &Url::parse("https://httpbin.org/get")?);
     /// # Ok(()) }

--- a/src/request_builder.rs
+++ b/src/request_builder.rs
@@ -22,7 +22,7 @@ use std::task::{Context, Poll};
 /// # Examples
 ///
 /// ```rust
-/// # use surf::url::Url;
+/// # use surf::Url;
 /// # use surf::{http, Request};
 /// # #[async_std::main]
 /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
@@ -42,7 +42,7 @@ use std::task::{Context, Poll};
 /// ```
 ///
 /// ```rust
-/// # use surf::url::Url;
+/// # use surf::Url;
 /// # use surf::{http, Request};
 /// # #[async_std::main]
 /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
@@ -74,7 +74,7 @@ impl RequestBuilder {
     /// # #[async_std::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     /// use surf::http::Method;
-    /// use surf::url::Url;
+    /// use surf::Url;
     ///
     /// let method = Method::Get;
     /// let url = Url::parse("https://httpbin.org/get")?;


### PR DESCRIPTION
The url crate is part of http-types; there is no need to re-export the full submodule from here. This cleans up the module index slightly. Thanks!