### PR TITLE
RequestBuilder: add .query()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ log = { version = "0.4.7", features = ["kv_unstable"] }
 mime_guess = "2.0.3"
 serde = "1.0.97"
 serde_json = "1.0.40"
-serde_urlencoded = "0.6.1"
 url = "2.0.0"
 http-client = { version = "6.0.0", default-features = false }
 http-types = "2.0.0"

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,7 +1,7 @@
 use crate::http::{
     self,
     headers::{self, HeaderName, HeaderValues, ToHeaderValues},
-    Body, Error, Method, Mime,
+    Body, Method, Mime,
 };
 use crate::RequestBuilder;
 
@@ -89,14 +89,8 @@ impl Request {
     /// assert_eq!(page, 2);
     /// # Ok(()) }
     /// ```
-    pub fn query<T: serde::de::DeserializeOwned>(&self) -> Result<T, Error> {
-        use std::io::{Error, ErrorKind};
-        let query = self
-            .req
-            .url()
-            .query()
-            .ok_or_else(|| Error::from(ErrorKind::InvalidData))?;
-        Ok(serde_urlencoded::from_str(query)?)
+    pub fn query<T: serde::de::DeserializeOwned>(&self) -> crate::Result<T> {
+        self.req.query()
     }
 
     /// Set the URL querystring.
@@ -119,16 +113,8 @@ impl Request {
     /// assert_eq!(req.as_ref().url().as_str(), "https://httpbin.org/get?page=2");
     /// # Ok(()) }
     /// ```
-    pub fn set_query(
-        &mut self,
-        query: &(impl Serialize + ?Sized),
-    ) -> Result<(), serde_urlencoded::ser::Error> {
-        let query = serde_urlencoded::to_string(query)?;
-        self.req.url_mut().set_query(Some(&query));
-
-        *self.req.url_mut() = self.req.url().clone();
-
-        Ok(())
+    pub fn set_query(&mut self, query: &impl Serialize) -> crate::Result<()> {
+        self.req.set_query(query)
     }
 
     /// Get an HTTP header.

--- a/src/request_builder.rs
+++ b/src/request_builder.rs
@@ -2,7 +2,7 @@ use crate::http::{
     headers::{HeaderName, ToHeaderValues},
     Body, Method, Mime,
 };
-use crate::{Client, Request, Response, Result};
+use crate::{Client, Error, Request, Response, Result};
 
 use futures_util::future::BoxFuture;
 use serde::Serialize;
@@ -161,10 +161,7 @@ impl RequestBuilder {
     /// assert_eq!(req.as_ref().url().as_str(), "https://httpbin.org/get?page=2");
     /// # Ok(()) }
     /// ```
-    pub fn query(
-        mut self,
-        query: &(impl Serialize + ?Sized),
-    ) -> std::result::Result<Self, serde_urlencoded::ser::Error> {
+    pub fn query(mut self, query: &impl Serialize) -> std::result::Result<Self, Error> {
         self.req.as_mut().unwrap().set_query(query)?;
 
         Ok(self)

--- a/src/request_builder.rs
+++ b/src/request_builder.rs
@@ -5,6 +5,7 @@ use crate::http::{
 use crate::{Client, Request, Response, Result};
 
 use futures_util::future::BoxFuture;
+use serde::Serialize;
 use url::Url;
 
 use std::fmt;
@@ -94,6 +95,9 @@ impl RequestBuilder {
     }
 
     /// Sets a header on the request.
+    ///
+    /// # Examples
+    ///
     /// ```
     /// let req = surf::get("https://httpbin.org/get").header("header-name", "header-value").build();
     /// assert_eq!(req["header-name"], "header-value");
@@ -104,6 +108,9 @@ impl RequestBuilder {
     }
 
     /// Sets the Content-Type header on the request.
+    ///
+    /// # Examples
+    ///
     /// ```
     /// # use surf::http::mime;
     /// let req = surf::post("https://httpbin.org/post").content_type(mime::HTML).build();
@@ -118,6 +125,9 @@ impl RequestBuilder {
     }
 
     /// Sets the body of the request.
+    ///
+    /// # Examples
+    ///
     /// ```
     /// # #[async_std::main]
     /// # async fn main() -> surf::Result<()> {
@@ -130,6 +140,34 @@ impl RequestBuilder {
     pub fn body(mut self, body: impl Into<Body>) -> Self {
         self.req.as_mut().unwrap().set_body(body);
         self
+    }
+
+    /// Set the URL querystring.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use serde::{Deserialize, Serialize};
+    /// # #[async_std::main]
+    /// # async fn main() -> surf::Result<()> {
+    /// #[derive(Serialize, Deserialize)]
+    /// struct Index {
+    ///     page: u32
+    /// }
+    ///
+    /// let query = Index { page: 2 };
+    /// let mut req = surf::get("https://httpbin.org/get").query(&query)?.build();
+    /// assert_eq!(req.url().query(), Some("page=2"));
+    /// assert_eq!(req.as_ref().url().as_str(), "https://httpbin.org/get?page=2");
+    /// # Ok(()) }
+    /// ```
+    pub fn query(
+        mut self,
+        query: &(impl Serialize + ?Sized),
+    ) -> std::result::Result<Self, serde_urlencoded::ser::Error> {
+        self.req.as_mut().unwrap().set_query(query)?;
+
+        Ok(self)
     }
 
     /// Submit the request and get the response body as bytes.


### PR DESCRIPTION
This was missing form the original RequestBuilder. My bad.

This would be very handy for me, so I'm pretty eager to get it in asap.