### PR TITLE
Client, RB: remove BoxFuture from .send()

### DIFF
--- a/src/request_builder.rs
+++ b/src/request_builder.rs
@@ -223,11 +223,12 @@ impl RequestBuilder {
     }
 
     /// Create a `Client` and send the constructed `Request` from it.
-    pub fn send(mut self) -> BoxFuture<'static, Result<Response>> {
+    pub async fn send(mut self) -> Result<Response> {
         self.client
             .take()
             .unwrap_or_else(Client::new_shared_or_panic)
             .send(self.build())
+            .await
     }
 }
 
@@ -243,12 +244,13 @@ impl Future for RequestBuilder {
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         if self.fut.is_none() {
             let req = self.req.take().unwrap();
-            if let Some(client) = &self.client {
-                self.fut = Some(client.send(req))
-            } else {
-                let client = Client::new_shared_or_panic();
-                self.fut = Some(client.send(req))
-            }
+
+            let client = self
+                .client
+                .take()
+                .unwrap_or_else(Client::new_shared_or_panic);
+
+            self.fut = Some(Box::pin(async move { client.send(req).await }))
         }
 
         // We can safely unwrap here because this is the only time we take ownership of the request.


### PR DESCRIPTION
The pinned future stored inside RequestBuilder for `.poll()` must be `'static` for _reasons_.

This moves the public facing `.send()` apis to use async functions, which instead return an `impl Future` on the stack.

(Link to some additional notes in discord: https://discordapp.com/channels/598880689856970762/649056351385026579/761629816763449375)

> 
> 9:44 AM] Fishrock: @jbr so I have a patch to remove the BoxedFuture from send properly — but I am curious, why did you want this?
> [9:46 AM] Fishrock: .send() seems like an apt place to go into a pointer, due to stack sizing for futures. (This is nitty gritty opt) I suppose this gives the user more control tho.
> [9:46 AM] Fishrock: (Ideally every futures stack would fit entirely into like L2/L3 cpu Cache)
> [9:51 AM] jbr: in general because my assumption is that externally facing apis should be impl Future (async functions), since that's async rust's general convention for everything except async traits

