### PR TITLE
2.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://book.async.rs/overview
 
 ## [Unreleased]
 
+## [2.0.0-alpha.7] - 2020-09-29
+
+### Fixes
+- Downgrade rust_2018_idioms from forbid to warn for compilation with newer deps.
+
+
 ## [2.0.0-alpha.6] - 2020-09-27
 
 This is an alpha release in preparation of 2.0.0, so you can start using Surf with stable futures. The aim is for this to be the last 2.0 alpha release.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "surf"
-version = "2.0.0-alpha.7"
+version = "2.0.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/http-rs/surf"
 documentation = "https://docs.rs/surf"


### PR DESCRIPTION
Here's a reasonably filled out changelog.

Plan: release ~~pacific time tomorrow (saturday).~~ monday oct 5

[**Rendered**](https://github.com/http-rs/surf/blob/b5f329b2fd57766859cba7257507c348f7263149/CHANGELOG.md)

> This major release of Surf contains substantial improvements through a variety of changes and additions.
> 
> Notable mentions include:
> - Uses stable standard library `futures`!
> - Much more type compatibility with Tide via http-types!
> - Re-usable `Client` which is able to make use of connection pooling under the hood.
> - Reduced generics for `Client` and `Middleware`.
> - Re-worked `Middleware` to use `async_trait`.