### PR TITLE
Remove url direct dep (rebase and extension of #243)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,9 +34,8 @@ log = { version = "0.4.7", features = ["kv_unstable"] }
 mime_guess = "2.0.3"
 serde = "1.0.97"
 serde_json = "1.0.40"
-url = "2.0.0"
 http-client = { version = "6.0.0", default-features = false }
-http-types = "2.0.0"
+http-types = "2.5.0"
 async-std = { version = "1.6.0", default-features = false, features = ["std"] }
 async-trait = "0.1.36"
 pin-project-lite = "0.1.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,12 +86,10 @@ pub mod middleware;
 pub mod utils;
 
 #[doc(inline)]
-pub use http_types::{self as http, Body, Error, Status, StatusCode};
+pub use http_types::{self as http, Body, Error, Status, StatusCode, Url};
 
 #[doc(inline)]
 pub use http_client::HttpClient;
-
-pub use url;
 
 pub use client::Client;
 pub use request::Request;

--- a/src/middleware/redirect/mod.rs
+++ b/src/middleware/redirect/mod.rs
@@ -12,9 +12,8 @@
 //! # Ok(()) }
 //! ```
 
-use crate::http::{headers, StatusCode};
+use crate::http::{headers, StatusCode, Url};
 use crate::middleware::{Middleware, Next, Request, Response};
-use crate::url::Url;
 use crate::{Client, Result};
 
 // List of acceptible 300-series redirect codes.

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,12 +1,11 @@
 use crate::http::{
     self,
     headers::{self, HeaderName, HeaderValues, ToHeaderValues},
-    Body, Method, Mime,
+    Body, Method, Mime, Url,
 };
 use crate::RequestBuilder;
 
 use serde::Serialize;
-use url::Url;
 
 use std::fmt;
 use std::ops::Index;
@@ -30,12 +29,10 @@ impl Request {
     /// ```no_run
     /// # #[async_std::main]
     /// # async fn main() -> surf::Result<()> {
-    /// use surf::http::Method;
-    /// use surf::Url;
+    /// use surf::http::{Url, Method};
     ///
-    /// let method = Method::Get;
     /// let url = Url::parse("https://httpbin.org/get")?;
-    /// let req = surf::Request::new(method, url);
+    /// let req = surf::Request::new(Method::Get, url);
     /// # Ok(()) }
     /// ```
     pub fn new(method: Method, url: Url) -> Self {
@@ -47,19 +44,18 @@ impl Request {
     ///
     /// # Example:
     /// ```rust
-    /// # use surf::Url;
-    /// # use surf::{http, Request};
+    /// use surf::http::{Method, mime::HTML, Url};
     /// # #[async_std::main]
     /// # async fn main() -> surf::Result<()> {
     /// let url = Url::parse("https://httpbin.org/post")?;
-    /// let mut request = Request::builder(http::Method::Post, url.clone())
+    /// let mut request = surf::Request::builder(Method::Post, url.clone())
     ///     .body("<html>hi</html>")
     ///     .header("custom-header", "value")
-    ///     .content_type(http::mime::HTML)
+    ///     .content_type(HTML)
     ///     .build();
     ///
     /// assert_eq!(request.take_body().into_string().await.unwrap(), "<html>hi</html>");
-    /// assert_eq!(request.method(), http::Method::Post);
+    /// assert_eq!(request.method(), Method::Post);
     /// assert_eq!(request.url(), &url);
     /// assert_eq!(request["custom-header"], "value");
     /// assert_eq!(request["content-type"], "text/html;charset=utf-8");

--- a/src/request.rs
+++ b/src/request.rs
@@ -31,7 +31,7 @@ impl Request {
     /// # #[async_std::main]
     /// # async fn main() -> surf::Result<()> {
     /// use surf::http::Method;
-    /// use surf::url::Url;
+    /// use surf::Url;
     ///
     /// let method = Method::Get;
     /// let url = Url::parse("https://httpbin.org/get")?;
@@ -47,7 +47,7 @@ impl Request {
     ///
     /// # Example:
     /// ```rust
-    /// # use surf::url::Url;
+    /// # use surf::Url;
     /// # use surf::{http, Request};
     /// # #[async_std::main]
     /// # async fn main() -> surf::Result<()> {
@@ -234,7 +234,7 @@ impl Request {
     /// ```no_run
     /// # #[async_std::main]
     /// # async fn main() -> surf::Result<()> {
-    /// use surf::url::Url;
+    /// use surf::http::Url;
     /// let req = surf::get("https://httpbin.org/get").build();
     /// assert_eq!(req.url(), &Url::parse("https://httpbin.org/get")?);
     /// # Ok(()) }

--- a/src/request_builder.rs
+++ b/src/request_builder.rs
@@ -1,12 +1,11 @@
 use crate::http::{
     headers::{HeaderName, ToHeaderValues},
-    Body, Method, Mime,
+    Body, Method, Mime, Url,
 };
 use crate::{Client, Error, Request, Response, Result};
 
 use futures_util::future::BoxFuture;
 use serde::Serialize;
-use url::Url;
 
 use std::fmt;
 use std::future::Future;
@@ -22,18 +21,17 @@ use std::task::{Context, Poll};
 /// # Examples
 ///
 /// ```rust
-/// # use surf::Url;
-/// # use surf::{http, Request};
+/// use surf::http::{Method, mime::HTML, Url};
 /// # #[async_std::main]
 /// # async fn main() -> surf::Result<()> {
 /// let mut request = surf::post("https://httpbin.org/post")
 ///     .body("<html>hi</html>")
 ///     .header("custom-header", "value")
-///     .content_type(http::mime::HTML)
+///     .content_type(HTML)
 ///     .build();
 ///
 /// assert_eq!(request.take_body().into_string().await.unwrap(), "<html>hi</html>");
-/// assert_eq!(request.method(), http::Method::Post);
+/// assert_eq!(request.method(), Method::Post);
 /// assert_eq!(request.url(), &Url::parse("https://httpbin.org/post")?);
 /// assert_eq!(request["custom-header"], "value");
 /// assert_eq!(request["content-type"], "text/html;charset=utf-8");
@@ -42,12 +40,11 @@ use std::task::{Context, Poll};
 /// ```
 ///
 /// ```rust
-/// # use surf::Url;
-/// # use surf::{http, Request};
+/// use surf::http::{Method, Url};
 /// # #[async_std::main]
 /// # async fn main() -> surf::Result<()> {
 /// let url = Url::parse("https://httpbin.org/post")?;
-/// let request = Request::builder(http::Method::Post, url).build();
+/// let request = surf::Request::builder(Method::Post, url).build();
 /// # Ok(())
 /// # }
 /// ```
@@ -73,10 +70,8 @@ impl RequestBuilder {
     /// ```no_run
     /// # #[async_std::main]
     /// # async fn main() -> surf::Result<()> {
-    /// use surf::http::Method;
-    /// use surf::Url;
+    /// use surf::http::{Method, Url};
     ///
-    /// let method = Method::Get;
     /// let url = Url::parse("https://httpbin.org/get")?;
     /// let req = surf::RequestBuilder::new(Method::Get, url).build();
     /// # Ok(()) }

--- a/src/request_builder.rs
+++ b/src/request_builder.rs
@@ -22,7 +22,7 @@ use std::task::{Context, Poll};
 /// # Examples
 ///
 /// ```rust
-/// # use surf::url::Url;
+/// # use surf::Url;
 /// # use surf::{http, Request};
 /// # #[async_std::main]
 /// # async fn main() -> surf::Result<()> {
@@ -42,7 +42,7 @@ use std::task::{Context, Poll};
 /// ```
 ///
 /// ```rust
-/// # use surf::url::Url;
+/// # use surf::Url;
 /// # use surf::{http, Request};
 /// # #[async_std::main]
 /// # async fn main() -> surf::Result<()> {
@@ -74,7 +74,7 @@ impl RequestBuilder {
     /// # #[async_std::main]
     /// # async fn main() -> surf::Result<()> {
     /// use surf::http::Method;
-    /// use surf::url::Url;
+    /// use surf::Url;
     ///
     /// let method = Method::Get;
     /// let url = Url::parse("https://httpbin.org/get")?;


### PR DESCRIPTION
This is a rebase of #243 for easier merging (and I didn't want to force-push to @yoshuawuyts's branch). I also removed the direct dep on the url crate, and instead rely on the http::Url re-export in this crate as well