### PR TITLE
Fix client base URL documentation

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -501,13 +501,17 @@ impl Client {
 
     /// Sets the base URL for this client. All request URLs will be relative to this URL.
     ///
+    /// Note: a trailing slash is significant.
+    /// Without it, the last path component is considered to be a “file” name
+    /// to be removed to get at the “directory” that is used as the base.
+    ///
     /// # Examples
     /// ```no_run
     /// # use http_types::Url;
     /// # fn main() -> http_types::Result<()> { async_std::task::block_on(async {
     /// let mut client = surf::client();
-    /// client.set_base_url(Url::parse("http://example.com/api/v1")?);
-    /// client.get("/posts.json").recv_json().await?; /// http://example.com/api/v1/posts.json
+    /// client.set_base_url(Url::parse("http://example.com/api/v1/")?);
+    /// client.get("posts.json").recv_json().await?; /// http://example.com/api/v1/posts.json
     /// # Ok(()) }) }
     /// ```
     pub fn set_base_url(&mut self, base: Url) {
@@ -520,5 +524,19 @@ impl Client {
             None => uri.as_ref().parse().unwrap(),
             Some(base) => base.join(uri.as_ref()).unwrap(),
         }
+    }
+}
+
+#[cfg(test)]
+mod client_tests {
+    use super::Client;
+    use crate::Url;
+
+    #[test]
+    fn base_url() {
+        let mut client = Client::new();
+        client.set_base_url(Url::parse("http://example.com/api/v1/").unwrap());
+        let url = client.url("posts.json");
+        assert_eq!(url.as_str(), "http://example.com/api/v1/posts.json");
     }
 }


### PR DESCRIPTION
The client base URL example sets the base URL to
"http://example.com/api/v1", which is then joined with a URI of
"/posts.json". This had two bugs:

- The base url did not end with '/', and so 'v1' was treated as a file
path, and dropped from the result. This lead to resulting URLs like:
"http://example.com/api/posts.json", without the 'v1'.
- the joined URI (/posts.json) begins with a '/', and so it was treated as an absolute
path from the domain. This lead to resulting URLs like:
"http://example.com/posts.json", without the '/api/v1'.

This commit fixes both of these bugs in the example. It also adds a note
to the documentation (copied from the URL crate) about the importance of
the ending '/'.

One test was added to ensure the base_url behavior.