### PR TITLE
feat: AsRef & AsMut <Headers> for Request & Response

### DIFF
--- a/examples/next_reuse.rs
+++ b/examples/next_reuse.rs
@@ -1,4 +1,5 @@
 use futures_util::io::AsyncReadExt;
+use surf::http;
 use surf::middleware::{Middleware, Next};
 use surf::{Body, Client, Request, Response};
 
@@ -14,7 +15,8 @@ impl Middleware for Doubler {
     ) -> Result<Response, http_types::Error> {
         if req.method().is_safe() {
             let mut new_req = http_types::Request::new(req.method(), req.url().clone());
-            new_req.set_version(req.as_ref().version());
+            let http_req: &http::Request = req.as_ref();
+            new_req.set_version(http_req.version());
             let mut new_req: Request = new_req.into();
 
             for (name, value) in &req {

--- a/src/middleware/redirect/mod.rs
+++ b/src/middleware/redirect/mod.rs
@@ -12,7 +12,7 @@
 //! # Ok(()) }
 //! ```
 
-use crate::http::{headers, StatusCode, Url};
+use crate::http::{self, headers, StatusCode, Url};
 use crate::middleware::{Middleware, Next, Request, Response};
 use crate::{Client, Result};
 
@@ -97,7 +97,8 @@ impl Middleware for Redirect {
             let res: Response = client.send(r).await?;
             if REDIRECT_CODES.contains(&res.status()) {
                 if let Some(location) = res.header(headers::LOCATION) {
-                    *req.as_mut().url_mut() = Url::parse(location.last().as_str())?;
+                    let http_req: &mut http::Request = req.as_mut();
+                    *http_req.url_mut() = Url::parse(location.last().as_str())?;
                 }
             } else {
                 break;

--- a/src/request.rs
+++ b/src/request.rs
@@ -106,7 +106,7 @@ impl Request {
     /// let mut req = surf::get("https://httpbin.org/get").build();
     /// req.set_query(&query)?;
     /// assert_eq!(req.url().query(), Some("page=2"));
-    /// assert_eq!(req.as_ref().url().as_str(), "https://httpbin.org/get?page=2");
+    /// assert_eq!(req.url().as_str(), "https://httpbin.org/get?page=2");
     /// # Ok(()) }
     /// ```
     pub fn set_query(&mut self, query: &impl Serialize) -> crate::Result<()> {
@@ -360,6 +360,18 @@ impl Request {
     pub fn body_form(&mut self, form: &impl Serialize) -> crate::Result<()> {
         self.set_body(Body::from_form(form)?);
         Ok(())
+    }
+}
+
+impl AsRef<http::Headers> for Request {
+    fn as_ref(&self) -> &http::Headers {
+        self.req.as_ref()
+    }
+}
+
+impl AsMut<http::Headers> for Request {
+    fn as_mut(&mut self) -> &mut http::Headers {
+        self.req.as_mut()
     }
 }
 

--- a/src/request_builder.rs
+++ b/src/request_builder.rs
@@ -153,7 +153,7 @@ impl RequestBuilder {
     /// let query = Index { page: 2 };
     /// let mut req = surf::get("https://httpbin.org/get").query(&query)?.build();
     /// assert_eq!(req.url().query(), Some("page=2"));
-    /// assert_eq!(req.as_ref().url().as_str(), "https://httpbin.org/get?page=2");
+    /// assert_eq!(req.url().as_str(), "https://httpbin.org/get?page=2");
     /// # Ok(()) }
     /// ```
     pub fn query(mut self, query: &impl Serialize) -> std::result::Result<Self, Error> {

--- a/src/response.rs
+++ b/src/response.rs
@@ -327,6 +327,18 @@ impl Into<http::Response> for Response {
     }
 }
 
+impl AsRef<http::Headers> for Response {
+    fn as_ref(&self) -> &http::Headers {
+        self.res.as_ref()
+    }
+}
+
+impl AsMut<http::Headers> for Response {
+    fn as_mut(&mut self) -> &mut http::Headers {
+        self.res.as_mut()
+    }
+}
+
 impl AsRef<http::Response> for Response {
     fn as_ref(&self) -> &http::Response {
         &self.res


### PR DESCRIPTION
This adds `AsRef` and `AsMut` to `Headers` for `Request` and `Response`, similar to Tide, for compatibility with `http_types`.