### PR TITLE
docs: do not inline docs from deps that drift

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,10 +86,8 @@ mod response;
 pub mod middleware;
 pub mod utils;
 
-#[doc(inline)]
 pub use http_types::{self as http, Body, Error, Status, StatusCode, Url};
 
-#[doc(inline)]
 pub use http_client::HttpClient;
 
 pub use client::Client;


### PR DESCRIPTION
Inlining these docs causes them to be perpetually out-of-date, since Docs.rs only builds on the actual containing crate publish.