### PR TITLE
Add 'h1-client-rustls' feature relying on rustls

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         rust: [nightly]
-        backend: [curl-client, h1-client, hyper-client]
+        backend: [curl-client, 'h1-client native-tls', hyper-client]
 
     steps:
     - uses: actions/checkout@master

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         rust: [nightly]
-        backend: [curl-client, h1-client, hyper-client, h1-client-rustls]
+        backend: [curl-client, h1-client, hyper-client]
 
     steps:
     - uses: actions/checkout@master

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         rust: [nightly]
-        backend: [curl-client, h1-client, hyper-client]
+        backend: [curl-client, h1-client, hyper-client, h1-client-rustls]
 
     steps:
     - uses: actions/checkout@master

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,10 @@ edition = "2018"
 default = ["curl-client", "middleware-logger", "encoding"]
 curl-client = ["http-client/curl_client", "once_cell", "default-client"]
 h1-client = ["http-client/h1_client", "default-client"]
-h1-client-rustls = ["http-client/h1_client_rustls", "default-client"]
 hyper-client = ["http-client/hyper_client", "once_cell", "default-client", "async-std/tokio02"]
 wasm-client = ["http-client/wasm_client", "default-client"]
+native-tls = ["http-client/native-tls"]
+rustls = ["http-client/rustls"]
 default-client = []
 middleware-logger = []
 # requires web-sys for TextDecoder on wasm
@@ -36,8 +37,7 @@ log = { version = "0.4.7", features = ["kv_unstable"] }
 mime_guess = "2.0.3"
 serde = "1.0.97"
 serde_json = "1.0.40"
-# http-client = { version = "6.1.0", default-features = false }
-http-client = { git = "https://github.com/http-rs/http-client.git", branch = "main", default-features = false }
+http-client = { version = "6.3.0", default-features = false }
 http-types = "2.5.0"
 async-std = { version = "1.6.0", default-features = false, features = ["std"] }
 async-trait = "0.1.36"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ edition = "2018"
 default = ["curl-client", "middleware-logger", "encoding"]
 curl-client = ["http-client/curl_client", "once_cell", "default-client"]
 h1-client = ["http-client/h1_client", "default-client"]
+h1-client-rustls = ["http-client/h1_client_rustls", "default-client"]
 hyper-client = ["http-client/hyper_client", "once_cell", "default-client", "async-std/tokio02"]
 wasm-client = ["http-client/wasm_client", "default-client"]
 default-client = []
@@ -35,7 +36,8 @@ log = { version = "0.4.7", features = ["kv_unstable"] }
 mime_guess = "2.0.3"
 serde = "1.0.97"
 serde_json = "1.0.40"
-http-client = { version = "6.1.0", default-features = false }
+# http-client = { version = "6.1.0", default-features = false }
+http-client = { git = "https://github.com/http-rs/http-client.git", branch = "main", default-features = false }
 http-types = "2.5.0"
 async-std = { version = "1.6.0", default-features = false, features = ["std"] }
 async-trait = "0.1.36"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ log = { version = "0.4.7", features = ["kv_unstable"] }
 mime_guess = "2.0.3"
 serde = "1.0.97"
 serde_json = "1.0.40"
-http-client = { version = "6.3.0", default-features = false }
+http-client = { version = "6.3.1", default-features = false }
 http-types = "2.5.0"
 async-std = { version = "1.6.0", default-features = false, features = ["std"] }
 async-trait = "0.1.36"

--- a/src/client.rs
+++ b/src/client.rs
@@ -12,7 +12,7 @@ cfg_if! {
         use http_client::isahc::IsahcClient as DefaultClient;
     } else if #[cfg(feature = "wasm-client")] {
         use http_client::wasm::WasmClient as DefaultClient;
-    } else if #[cfg(feature = "h1-client")] {
+    } else if #[cfg(any(feature = "h1-client", feature = "h1-client-rustls"))] {
         use http_client::h1::H1Client as DefaultClient;
     } else if #[cfg(feature = "hyper-client")] {
         use http_client::hyper::HyperClient as DefaultClient;

--- a/src/client.rs
+++ b/src/client.rs
@@ -12,7 +12,7 @@ cfg_if! {
         use http_client::isahc::IsahcClient as DefaultClient;
     } else if #[cfg(feature = "wasm-client")] {
         use http_client::wasm::WasmClient as DefaultClient;
-    } else if #[cfg(any(feature = "h1-client", feature = "h1-client-rustls"))] {
+    } else if #[cfg(feature = "h1-client")] {
         use http_client::h1::H1Client as DefaultClient;
     } else if #[cfg(feature = "hyper-client")] {
         use http_client::hyper::HyperClient as DefaultClient;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,8 @@
 //! The following features are available. The default features are
 //! `curl-client`, `middleware-logger`, and `encoding`
 //! - __`curl-client` (default):__ use `curl` (through `isahc`) as the HTTP backend.
-//! - __`h1-client`:__ use `async-h1` as the HTTP backend.
+//! - __`h1-client`:__ use `async-h1` as the HTTP backend with OpenSSL for HTTPS.
+//! - __`h1-client-rustls`:__ use `async-h1` as the HTTP backend with `rustls` for HTTPS.
 //! - __`hyper-client`:__ use `hyper` (hyper.rs) as the HTTP backend.
 //! - __`wasm-client`:__ use `window.fetch` as the HTTP backend.
 //! - __`middleware-logger` (default):__ enables logging requests and responses using a middleware.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,10 +65,11 @@
 //! The following features are available. The default features are
 //! `curl-client`, `middleware-logger`, and `encoding`
 //! - __`curl-client` (default):__ use `curl` (through `isahc`) as the HTTP backend.
-//! - __`h1-client`:__ use `async-h1` as the HTTP backend with OpenSSL for HTTPS.
-//! - __`h1-client-rustls`:__ use `async-h1` as the HTTP backend with `rustls` for HTTPS.
+//! - __`h1-client`:__ use `async-h1` as the HTTP backend. For HTTPS, you also need either `native-tls` (to use OpenSSL) or either `rustls`.
 //! - __`hyper-client`:__ use `hyper` (hyper.rs) as the HTTP backend.
 //! - __`wasm-client`:__ use `window.fetch` as the HTTP backend.
+//! - __`native-tls`:__ use OpenSSL for HTTPS (currently only usefull in addition of `h1-client`).
+//! - __`rustls`:__ use rustls for HTTPS (currently only usefull in addition of `h1-client`).
 //! - __`middleware-logger` (default):__ enables logging requests and responses using a middleware.
 //! - __`encoding` (default):__ enables support for body encodings other than utf-8
 


### PR DESCRIPTION
This PR is a follow-up of http-rs/http-client#53 and addresses #40.
It adds a `h1-client-rustls` feature using `http-client/h1_client_rustls` feature introduced by http-rs/http-client#53.

**TODO**: 
For testing purpose I set the dependency to `http-client` to directly use its Git repo.
Once http-client is released with http-rs/http-client#53, update the dependency to use the latest version.