### PR TITLE
Fix h1-client and default-client feature

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,3 +87,17 @@ jobs:
 
     - name: docs
       run: cargo doc --no-deps
+
+  check_features:
+    name: Check feature combinations
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+
+    - name: Install cargo-hack
+      run: cargo install cargo-hack
+
+    - name: Check all feature combinations works properly
+      # * `--feature-powerset` - run for the feature powerset of the package
+      # * `--no-dev-deps` - build without dev-dependencies to avoid https://github.com/rust-lang/cargo/issues/4866
+      run: cargo hack check --feature-powerset --no-dev-deps

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ curl-client = ["http-client/curl_client", "once_cell", "default-client"]
 h1-client = ["http-client/h1_client", "http-client/native-tls", "default-client"]
 hyper-client = ["http-client/hyper_client", "once_cell", "default-client", "async-std/tokio02"]
 wasm-client = ["http-client/wasm_client", "default-client"]
+# this feature flag is no longer necessary.
 default-client = []
 middleware-logger = []
 # requires web-sys for TextDecoder on wasm

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ description = "Surf the web - HTTP client framework"
 keywords = ["http", "client", "framework", "request", "async"]
 categories = ["web-programming", "web-programming::http-client"]
 authors = [
-    "Yoshua Wuyts <yoshuawuyts@gmail.com>", 
+    "Yoshua Wuyts <yoshuawuyts@gmail.com>",
     "dignifiedquire <me@dignifiedquire.com>",
     "Renée Kooi <renee@kooi.me>",
     "Jeremiah Senkpiel <fishrock123@rocketmail.com>"
@@ -21,7 +21,7 @@ edition = "2018"
 # `.github/workflows/ci.yaml` are updated accordingly
 default = ["curl-client", "middleware-logger", "encoding"]
 curl-client = ["http-client/curl_client", "once_cell", "default-client"]
-h1-client = ["http-client/h1_client", "default-client"]
+h1-client = ["http-client/h1_client", "http-client/native-tls", "default-client"]
 hyper-client = ["http-client/hyper_client", "once_cell", "default-client", "async-std/tokio02"]
 wasm-client = ["http-client/wasm_client", "default-client"]
 default-client = []
@@ -35,7 +35,7 @@ log = { version = "0.4.7", features = ["kv_unstable"] }
 mime_guess = "2.0.3"
 serde = "1.0.97"
 serde_json = "1.0.40"
-http-client = { version = "6.1.0", default-features = false }
+http-client = { version = "6.3.0", default-features = false }
 http-types = "2.5.0"
 async-std = { version = "1.6.0", default-features = false, features = ["std"] }
 async-trait = "0.1.36"

--- a/src/client.rs
+++ b/src/client.rs
@@ -76,14 +76,11 @@ impl fmt::Debug for Client {
     }
 }
 
-#[cfg(all(
-    feature = "default-client",
-    any(
-        feature = "curl-client",
-        all(feature = "wasm-client", target_arch = "wasm32"),
-        feature = "h1-client",
-        feature = "hyper-client"
-    )
+#[cfg(any(
+    feature = "curl-client",
+    all(feature = "wasm-client", target_arch = "wasm32"),
+    feature = "h1-client",
+    feature = "hyper-client"
 ))]
 impl Default for Client {
     fn default() -> Self {
@@ -105,14 +102,11 @@ impl Client {
     /// let res = client.send(req).await?;
     /// # Ok(()) }
     /// ```
-    #[cfg(all(
-        feature = "default-client",
-        any(
-            feature = "curl-client",
-            all(feature = "wasm-client", target_arch = "wasm32"),
-            feature = "h1-client",
-            feature = "hyper-client"
-        )
+    #[cfg(any(
+        feature = "curl-client",
+        all(feature = "wasm-client", target_arch = "wasm32"),
+        feature = "h1-client",
+        feature = "hyper-client"
     ))]
     pub fn new() -> Self {
         Self::with_http_client(DefaultClient::new())
@@ -120,14 +114,11 @@ impl Client {
 
     pub(crate) fn new_shared_or_panic() -> Self {
         cfg_if! {
-            if #[cfg(all(
-                feature = "default-client",
-                any(
-                    feature = "curl-client",
-                    all(feature = "wasm-client", target_arch = "wasm32"),
-                    feature = "h1-client",
-                    feature = "hyper-client"
-                )
+            if #[cfg(any(
+                feature = "curl-client",
+                all(feature = "wasm-client", target_arch = "wasm32"),
+                feature = "h1-client",
+                feature = "hyper-client"
             ))] {
                 Self::new_shared()
             } else {
@@ -164,14 +155,11 @@ impl Client {
         client
     }
 
-    #[cfg(all(
-        feature = "default-client",
-        any(
-            feature = "curl-client",
-            all(feature = "wasm-client", target_arch = "wasm32"),
-            feature = "h1-client",
-            feature = "hyper-client"
-        )
+    #[cfg(any(
+        feature = "curl-client",
+        all(feature = "wasm-client", target_arch = "wasm32"),
+        feature = "h1-client",
+        feature = "hyper-client"
     ))]
     pub(crate) fn new_shared() -> Self {
         cfg_if! {

--- a/src/client.rs
+++ b/src/client.rs
@@ -10,7 +10,7 @@ use cfg_if::cfg_if;
 cfg_if! {
     if #[cfg(feature = "curl-client")] {
         use http_client::isahc::IsahcClient as DefaultClient;
-    } else if #[cfg(feature = "wasm-client")] {
+    } else if #[cfg(all(feature = "wasm-client", target_arch = "wasm32"))] {
         use http_client::wasm::WasmClient as DefaultClient;
     } else if #[cfg(feature = "h1-client")] {
         use http_client::h1::H1Client as DefaultClient;
@@ -76,7 +76,15 @@ impl fmt::Debug for Client {
     }
 }
 
-#[cfg(feature = "default-client")]
+#[cfg(all(
+    feature = "default-client",
+    any(
+        feature = "curl-client",
+        all(feature = "wasm-client", target_arch = "wasm32"),
+        feature = "h1-client",
+        feature = "hyper-client"
+    )
+))]
 impl Default for Client {
     fn default() -> Self {
         Self::new()
@@ -97,14 +105,30 @@ impl Client {
     /// let res = client.send(req).await?;
     /// # Ok(()) }
     /// ```
-    #[cfg(feature = "default-client")]
+    #[cfg(all(
+        feature = "default-client",
+        any(
+            feature = "curl-client",
+            all(feature = "wasm-client", target_arch = "wasm32"),
+            feature = "h1-client",
+            feature = "hyper-client"
+        )
+    ))]
     pub fn new() -> Self {
         Self::with_http_client(DefaultClient::new())
     }
 
     pub(crate) fn new_shared_or_panic() -> Self {
         cfg_if! {
-            if #[cfg(feature = "default-client")] {
+            if #[cfg(all(
+                feature = "default-client",
+                any(
+                    feature = "curl-client",
+                    all(feature = "wasm-client", target_arch = "wasm32"),
+                    feature = "h1-client",
+                    feature = "hyper-client"
+                )
+            ))] {
                 Self::new_shared()
             } else {
                 panic!("default client not configured")
@@ -140,7 +164,15 @@ impl Client {
         client
     }
 
-    #[cfg(feature = "default-client")]
+    #[cfg(all(
+        feature = "default-client",
+        any(
+            feature = "curl-client",
+            all(feature = "wasm-client", target_arch = "wasm32"),
+            feature = "h1-client",
+            feature = "hyper-client"
+        )
+    ))]
     pub(crate) fn new_shared() -> Self {
         cfg_if! {
             if #[cfg(any(feature = "curl-client", feature = "hyper-client"))] {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,14 +96,11 @@ pub use request_builder::RequestBuilder;
 pub use response::{DecodeError, Response};
 
 cfg_if::cfg_if! {
-    if #[cfg(all(
-        feature = "default-client",
-        any(
-            feature = "curl-client",
-            all(feature = "wasm-client", target_arch = "wasm32"),
-            feature = "h1-client",
-            feature = "hyper-client"
-        )
+    if #[cfg(any(
+        feature = "curl-client",
+        all(feature = "wasm-client", target_arch = "wasm32"),
+        feature = "h1-client",
+        feature = "hyper-client"
     ))] {
         mod one_off;
         pub use one_off::{connect, delete, get, head, options, patch, post, put, trace};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,7 +96,15 @@ pub use request_builder::RequestBuilder;
 pub use response::{DecodeError, Response};
 
 cfg_if::cfg_if! {
-    if #[cfg(feature = "default-client")] {
+    if #[cfg(all(
+        feature = "default-client",
+        any(
+            feature = "curl-client",
+            all(feature = "wasm-client", target_arch = "wasm32"),
+            feature = "h1-client",
+            feature = "hyper-client"
+        )
+    ))] {
         mod one_off;
         pub use one_off::{connect, delete, get, head, options, patch, post, put, trace};
 


### PR DESCRIPTION
Context: https://github.com/http-rs/http-client/pull/67#issuecomment-778734155

This also adds a CI task to check all feature combinations work properly. (This is almost the same as that used in [crossbeam](https://github.com/crossbeam-rs/crossbeam/blob/ae5ca20f9235cdee5601c5f31864e4c873c209a3/ci/check-features.sh), [futures-rs](https://github.com/rust-lang/futures-rs/blob/59f62b04d92a236a9909e3ef0ed6cf973ad9d593/.github/workflows/ci.yml#L208-L227), [hyper](https://github.com/hyperium/hyper/blob/42587059e6175735b1a8656c5ddbff0edb19294c/.github/workflows/CI.yml#L96-L115), etc.)