### PR TITLE
feat: globally share h1 client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,8 @@ edition = "2018"
 # `.github/workflows/ci.yaml` are updated accordingly
 default = ["curl-client", "middleware-logger", "encoding"]
 curl-client = ["http-client/curl_client", "once_cell", "default-client"]
-h1-client = ["http-client/h1_client", "http-client/native-tls", "default-client"]
-h1-client-rustls = ["http-client/h1_client", "http-client/rustls", "default-client"]
+h1-client = ["http-client/h1_client", "http-client/native-tls", "once_cell", "default-client"]
+h1-client-rustls = ["http-client/h1_client", "http-client/rustls", "once_cell", "default-client"]
 hyper-client = ["http-client/hyper_client", "once_cell", "default-client", "async-std/tokio02"]
 wasm-client = ["http-client/wasm_client", "default-client"]
 default-client = []
@@ -36,7 +36,7 @@ log = { version = "0.4.7", features = ["kv_unstable"] }
 mime_guess = "2.0.3"
 serde = "1.0.97"
 serde_json = "1.0.40"
-http-client = { version = "6.3.1", default-features = false }
+http-client = { version = "6.3.4", default-features = false }
 http-types = "2.5.0"
 async-std = { version = "1.6.0", default-features = false, features = ["std"] }
 async-trait = "0.1.36"

--- a/src/client.rs
+++ b/src/client.rs
@@ -19,7 +19,7 @@ cfg_if! {
     }
 }
 cfg_if! {
-    if #[cfg(any(feature = "curl-client", feature = "hyper-client"))] {
+    if #[cfg(any(feature = "curl-client", feature = "h1-client", feature = "h1-client-rustls", feature = "hyper-client"))] {
         use once_cell::sync::Lazy;
         static GLOBAL_CLIENT: Lazy<Arc<DefaultClient>> = Lazy::new(|| Arc::new(DefaultClient::new()));
     }
@@ -143,7 +143,7 @@ impl Client {
     #[cfg(feature = "default-client")]
     pub(crate) fn new_shared() -> Self {
         cfg_if! {
-            if #[cfg(any(feature = "curl-client", feature = "hyper-client"))] {
+            if #[cfg(any(feature = "curl-client", feature = "h1-client", feature = "h1-client-rustls", feature = "hyper-client"))] {
                 Self::with_http_client_internal(GLOBAL_CLIENT.clone())
             } else {
                 Self::new()

--- a/src/request.rs
+++ b/src/request.rs
@@ -275,6 +275,7 @@ impl Request {
     /// E.g. a string, or a buffer. Consumers of this API should check this
     /// value to decide whether to use `Chunked` encoding, or set the
     /// response length.
+    #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> Option<usize> {
         self.req.len()
     }

--- a/src/response.rs
+++ b/src/response.rs
@@ -161,6 +161,7 @@ impl Response {
     /// E.g. a string, or a buffer. Consumers of this API should check this
     /// value to decide whether to use `Chunked` encoding, or set the
     /// response length.
+    #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> Option<usize> {
         self.res.len()
     }


### PR DESCRIPTION
This actually takes advantage of the new connection pooling in the
async-h1 client.

~~This is a draft because it runs us into bugs in the connection pooling, observable in the tests: https://github.com/http-rs/http-client/issues/75~~