### PR TITLE
Add specialized body types to `RequestBuilder`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@
 //!
 //! let uri = "https://httpbin.org/post";
 //! let data = &Ip { ip: "129.0.0.1".into() };
-//! let res = surf::post(uri).body(surf::Body::from_json(data)?).await?;
+//! let res = surf::post(uri).body_json(data)?.await?;
 //! assert_eq!(res.status(), 200);
 //!
 //! let uri = "https://api.ipify.org?format=json";

--- a/src/request.rs
+++ b/src/request.rs
@@ -308,7 +308,7 @@ impl Request {
     ///
     /// # Mime
     ///
-    /// The encoding is set to `application/json`.
+    /// The `content-type` is set to `application/json`.
     ///
     /// # Errors
     ///
@@ -322,7 +322,7 @@ impl Request {
     ///
     /// # Mime
     ///
-    /// The encoding is set to `text/plain; charset=utf-8`.
+    /// The `content-type` is set to `text/plain; charset=utf-8`.
     pub fn body_string(&mut self, string: String) {
         self.set_body(Body::from_string(string))
     }
@@ -331,7 +331,7 @@ impl Request {
     ///
     /// # Mime
     ///
-    /// The encoding is set to `application/octet-stream`.
+    /// The `content-type` is set to `application/octet-stream`.
     pub fn body_bytes(&mut self, bytes: impl AsRef<[u8]>) {
         self.set_body(Body::from(bytes.as_ref()))
     }
@@ -340,7 +340,7 @@ impl Request {
     ///
     /// # Mime
     ///
-    /// The encoding is set based on the file extension using [`mime_guess`] if the operation was
+    /// The `content-type` is set based on the file extension using [`mime_guess`] if the operation was
     /// successful. If `path` has no extension, or its extension has no known MIME type mapping,
     /// then `None` is returned.
     ///
@@ -359,7 +359,7 @@ impl Request {
     ///
     /// # Mime
     ///
-    /// The encoding is set to `application/x-www-form-urlencoded`.
+    /// The `content-type` is set to `application/x-www-form-urlencoded`.
     ///
     /// # Errors
     ///

--- a/src/request_builder.rs
+++ b/src/request_builder.rs
@@ -120,7 +120,7 @@ impl RequestBuilder {
         self
     }
 
-    /// Pass an `AsyncRead` stream as the request body.
+    /// Sets the body of the request from any type with implements `Into<Body>`, for example, any type with is `AsyncRead`.
     /// # Mime
     ///
     /// The encoding is set to `application/octet-stream`.


### PR DESCRIPTION
I was doing a coding exercise and realized that both `surf::RequestBuilder` and `tide::ResponseBuilder` didn't have body shorthand methods yet. This makes it so `surf::RequestBuilder` is closer to `surf::Request`, making it easier to write. Thanks!

## Example

```rust
let uri = "https://httpbin.org/post";
let data = &Ip { ip: "129.0.0.1".into() };

// before
let res = surf::post(uri).body(Body::from_json(data)?).await?;

// after
let res = surf::post(uri).body_json(data)?.await?;
```