### PR TITLE
RequestBuilder from Client and user-provided method

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -523,6 +523,29 @@ impl Client {
         RequestBuilder::new(Method::Patch, self.url(uri)).with_client(self.clone())
     }
 
+    /// Perform a HTTP request with the given verb using the `Client` connection.
+    ///
+    /// # Panics
+    ///
+    /// This will panic if a malformed URL is passed.
+    ///
+    /// # Errors
+    ///
+    /// Returns errors from the middleware, http backend, and network sockets.
+    ///
+    /// # Examples
+    /// ```no_run
+    /// # #[async_std::main]
+    /// # async fn main() -> surf::Result<()> {
+    /// let client = surf::client();
+    /// let req = client.request(Method::Get, "http://httpbin.org/get");
+    /// let res = client.send(req).await?;
+    /// # Ok(()) }
+    /// ```
+    pub fn request(&self, verb: Method, uri: impl AsRef<str>) -> RequestBuilder {
+        RequestBuilder::new(verb, self.url(uri)).with_client(self.clone())
+    }
+
     /// Sets the base URL for this client. All request URLs will be relative to this URL.
     ///
     /// Note: a trailing slash is significant.

--- a/src/client.rs
+++ b/src/client.rs
@@ -537,6 +537,7 @@ impl Client {
     /// ```no_run
     /// # #[async_std::main]
     /// # async fn main() -> surf::Result<()> {
+    /// use http_types::Method;
     /// let client = surf::client();
     /// let req = client.request(Method::Get, "http://httpbin.org/get");
     /// let res = client.send(req).await?;


### PR DESCRIPTION
Let me know if this change was intended in the conversation from https://github.com/http-rs/surf/issues/260. 

Tested by just running the code sample in the doc. There do not seem to be unit tests for other similar client methods and so this also does not have any.