### PR TITLE
tests: fix wasm tests by setting a getrandom feature

### DIFF
--- a/wasm-test/Cargo.toml
+++ b/wasm-test/Cargo.toml
@@ -5,6 +5,10 @@ edition = "2018"
 
 [dependencies]
 surf = { path = "..", default-features = false, features = ["wasm-client"] }
-wasm-bindgen-test = "0.3.18"
+wasm-bindgen-test = "0.3.24"
 async-std = "1.6.4"
 serde_json = "1.0.57"
+
+[dependencies.getrandom]
+version = "0.2"
+features = ["js"]


### PR DESCRIPTION
See https://docs.rs/getrandom/0.2.3/getrandom/#unsupported-targets