### PR TITLE
fix: pin getrandom to work on wasm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,10 @@ cfg-if = "1.0.0"
 # encoding
 encoding_rs = { version = "0.8.20", optional = true }
 
-# wasm-client
+# wasm-client config
+[target.'cfg(target_arch = "wasm32")'.dependencies.getrandom]
+version = "0.2"
+features = ["js"]
 [target.'cfg(target_arch = "wasm32")'.dependencies.web-sys]
 version = "0.3.25"
 optional = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,12 @@ hyper-client = [
     "default-client",
     "async-std/tokio02",
 ]
-wasm-client = ["http-client/wasm_client", "default-client"]
+wasm-client = [
+    "http-client/wasm_client",
+    "default-client",
+    "getrandom/js",
+    "web-sys",
+]
 default-client = []
 middleware-logger = []
 # requires web-sys for TextDecoder on wasm
@@ -58,19 +63,11 @@ async-trait = "0.1.36"
 pin-project-lite = "0.2.0"
 once_cell = { version = "1.4.1", optional = true }
 cfg-if = "1.0.0"
-
-[target.'cfg(not(feature = "wasm-client"))'.dependencies]
-# encoding
+getrandom = "0.2.0"
 encoding_rs = { version = "0.8.20", optional = true }
 
-# wasm-client config
-[target.'cfg(feature="wasm-client")'.dependencies.getrandom]
-version = "0.2"
-features = ["js"]
-[target.'cfg(feature="wasm-client")'.dependencies.web-sys]
-version = "0.3.25"
-optional = true
-features = ["TextDecoder"]
+web-sys = { optional = true, version = "0.3.25", features = ["TextDecoder"] }
+
 
 [dev-dependencies]
 async-std = { version = "1.6.0", features = ["attributes"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ authors = [
     "Yoshua Wuyts <yoshuawuyts@gmail.com>",
     "dignifiedquire <me@dignifiedquire.com>",
     "Renée Kooi <renee@kooi.me>",
-    "Jeremiah Senkpiel <fishrock123@rocketmail.com>"
+    "Jeremiah Senkpiel <fishrock123@rocketmail.com>",
 ]
 readme = "README.md"
 edition = "2018"
@@ -21,9 +21,24 @@ edition = "2018"
 # `.github/workflows/ci.yaml` are updated accordingly
 default = ["curl-client", "middleware-logger", "encoding"]
 curl-client = ["http-client/curl_client", "once_cell", "default-client"]
-h1-client = ["http-client/h1_client", "http-client/native-tls", "once_cell", "default-client"]
-h1-client-rustls = ["http-client/h1_client", "http-client/rustls", "once_cell", "default-client"]
-hyper-client = ["http-client/hyper_client", "once_cell", "default-client", "async-std/tokio02"]
+h1-client = [
+    "http-client/h1_client",
+    "http-client/native-tls",
+    "once_cell",
+    "default-client",
+]
+h1-client-rustls = [
+    "http-client/h1_client",
+    "http-client/rustls",
+    "once_cell",
+    "default-client",
+]
+hyper-client = [
+    "http-client/hyper_client",
+    "once_cell",
+    "default-client",
+    "async-std/tokio02",
+]
 wasm-client = ["http-client/wasm_client", "default-client"]
 default-client = []
 middleware-logger = []
@@ -44,20 +59,18 @@ pin-project-lite = "0.2.0"
 once_cell = { version = "1.4.1", optional = true }
 cfg-if = "1.0.0"
 
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+[target.'cfg(not(feature = "wasm-client"))'.dependencies]
 # encoding
 encoding_rs = { version = "0.8.20", optional = true }
 
 # wasm-client config
-[target.'cfg(target_arch = "wasm32")'.dependencies.getrandom]
+[target.'cfg(feature="wasm-client")'.dependencies.getrandom]
 version = "0.2"
 features = ["js"]
-[target.'cfg(target_arch = "wasm32")'.dependencies.web-sys]
+[target.'cfg(feature="wasm-client")'.dependencies.web-sys]
 version = "0.3.25"
 optional = true
-features = [
-    "TextDecoder",
-]
+features = ["TextDecoder"]
 
 [dev-dependencies]
 async-std = { version = "1.6.0", features = ["attributes"] }
@@ -66,4 +79,4 @@ serde = { version = "1.0.97", features = ["derive"] }
 mockito = "0.23.3"
 
 [workspace]
-members = [ "wasm-test" ]
+members = ["wasm-test"]

--- a/wasm-test/Cargo.toml
+++ b/wasm-test/Cargo.toml
@@ -9,6 +9,3 @@ wasm-bindgen-test = "0.3.24"
 async-std = "1.6.4"
 serde_json = "1.0.57"
 
-[dependencies.getrandom]
-version = "0.2"
-features = ["js"]


### PR DESCRIPTION
This PR pins getrandom to the "js" feature so that surf compiles on wasm32 again.

Solves #315 

Before this change, when I tried to build the repo for wasm:
```
cargo build --target wasm32-unknown-unknown --features wasm-client --no-default-features

   Compiling getrandom v0.2.3
error: the wasm32-unknown-unknown target is not supported by default, you may need to enable the "js" feature. For more information see: https://docs.rs/getrandom/#webassembly-support
   --> /Users/jonkelley/.cargo/registry/src/github.com-1ecc6299db9ec823/getrandom-0.2.3/src/lib.rs:219:9
    |
219 | /         compile_error!("the wasm32-unknown-unknown target is not supported by \
220 | |                         default, you may need to enable the \"js\" feature. \
221 | |                         For more information see: \
222 | |                         https://docs.rs/getrandom/#webassembly-support");
    | |_________________________________________________________________________^

error[E0433]: failed to resolve: use of undeclared crate or module `imp`
   --> /Users/jonkelley/.cargo/registry/src/github.com-1ecc6299db9ec823/getrandom-0.2.3/src/lib.rs:246:5
    |
246 |     imp::getrandom_inner(dest)
    |     ^^^ use of undeclared crate or module `imp`

error: aborting due to 2 previous errors

For more information about this error, try `rustc --explain E0433`.
error: could not compile `getrandom`

To learn more, run the command again with --verbose.

```

With these feature flags, I can build properly:

```
cargo build --target wasm32-unknown-unknown --features wasm-client --no-default-features

    Finished dev [unoptimized + debuginfo] target(s) in 0.13s
```