### PR TITLE
feat: add `Config::set_tls_config()` (h1 only)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ h1-client-rustls = [
     "http-client/rustls",
     "once_cell",
     "default-client",
+    "rustls_crate",
 ]
 hyper-client = [
     "http-client/hyper_client",
@@ -65,6 +66,7 @@ once_cell = { version = "1.4.1", optional = true }
 cfg-if = "1.0.0"
 getrandom = "0.2.0"
 encoding_rs = { version = "0.8.20", optional = true }
+rustls_crate = { version = "0.18", optional = true, package = "rustls" }
 
 web-sys = { optional = true, version = "0.3.25", features = ["TextDecoder"] }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -165,6 +165,27 @@ impl Config {
         self.http_client = Some(Arc::new(http_client));
         self
     }
+
+    /// Set TLS Configuration (Rustls)
+    #[cfg_attr(feature = "docs", doc(cfg(feature = "h1-client-rustls")))]
+    #[cfg(feature = "h1-client-rustls")]
+    pub fn set_tls_config(
+        mut self,
+        tls_config: Option<std::sync::Arc<rustls_crate::ClientConfig>>,
+    ) -> Self {
+        self.http_config.tls_config = tls_config;
+        self
+    }
+    /// Set TLS Configuration (Native TLS)
+    #[cfg_attr(feature = "docs", doc(cfg(feature = "h1-client")))]
+    #[cfg(feature = "h1_client")]
+    pub fn set_tls_config(
+        mut self,
+        tls_config: Option<std::sync::Arc<async_native_tls::TlsConnector>>,
+    ) -> Self {
+        self.http_config.tls_config = tls_config;
+        self
+    }
 }
 
 impl AsRef<HttpConfig> for Config {


### PR DESCRIPTION
Adds `Config::set_tls_config()` like `http-client` has. Note that this only works with the async-h1 `h1-client`, which is not yet the default.