### PR TITLE
Depend on http-types with only the "fs" feature, no other default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ mime_guess = "2.0.3"
 serde = "1.0.97"
 serde_json = "1.0.40"
 http-client = { version = "6.5.0", default-features = false }
-http-types = "2.5.0"
+http-types = { version = "2.5.0", default-features = false, features = ["fs"] }
 async-std = { version = "1.6.0", default-features = false, features = ["std"] }
 async-trait = "0.1.36"
 pin-project-lite = "0.2.0"


### PR DESCRIPTION
This allows users of surf to avoid the substantial dependency tree for
the "cookie" feature if they don't need it.
