### PR TITLE
feat: automatically insert content-length header with body_json function

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -315,7 +315,9 @@ impl Request {
     ///
     /// This method will return an error if the provided data could not be serialized to JSON.
     pub fn body_json(&mut self, json: &impl Serialize) -> crate::Result<()> {
-        self.set_body(Body::from_json(json)?);
+        let body: Body = Body::from_json(json)?;
+        self.set_header("Content-Length", body.len().unwrap().to_string());
+        self.set_body(body);
         Ok(())
     }
 


### PR DESCRIPTION
Automatically set the `content-length` header to HTTP requests. 

Resolves: #324

Signed-off-by: Yagiz Degirmenci <yagizcanilbey1903@gmail.com>