### PR TITLE
Allow building with `--all-features`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -100,4 +100,4 @@ jobs:
     - name: Check all feature combinations works properly
       # * `--feature-powerset` - run for the feature powerset of the package
       # * `--no-dev-deps` - build without dev-dependencies to avoid https://github.com/rust-lang/cargo/issues/4866
-      run: cargo hack check --feature-powerset --no-dev-deps --skip=default-client,wasm-client --skip=h1-client,h1-client-rustls
+      run: cargo hack check --feature-powerset --no-dev-deps --skip=default-client,wasm-client

--- a/src/config.rs
+++ b/src/config.rs
@@ -203,7 +203,7 @@ impl Config {
     }
     /// Set TLS Configuration (Native TLS)
     #[cfg_attr(feature = "docs", doc(cfg(feature = "h1-client")))]
-    #[cfg(feature = "h1-client")]
+    #[cfg(all(feature = "h1-client", not(feature = "h1-client-rustls")))]
     pub fn set_tls_config(
         mut self,
         tls_config: Option<std::sync::Arc<async_native_tls::TlsConnector>>,


### PR DESCRIPTION
`h1-client-rustls` is preferred when `h1-client` is also enabled.

I just want to use `h1-client-rustls` with sentry: https://github.com/getsentry/sentry-rust/pull/404
See https://github.com/rust-lang/cargo/issues/4328 and https://github.com/rust-lang/cargo/blob/master/src/doc/src/reference/features.md#feature-unification