### PR TITLE
Fix "could not find `wasm` in `http_client`" error

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -11,7 +11,7 @@ use cfg_if::cfg_if;
 cfg_if! {
     if #[cfg(feature = "curl-client")] {
         use http_client::isahc::IsahcClient as DefaultClient;
-    } else if #[cfg(feature = "wasm-client")] {
+    } else if #[cfg(all(feature = "wasm-client", target_arch = "wasm32"))] {
         use http_client::wasm::WasmClient as DefaultClient;
     } else if #[cfg(any(feature = "h1-client", feature = "h1-client-rustls", feature = "h1-client-no-tls"))] {
         use http_client::h1::H1Client as DefaultClient;


### PR DESCRIPTION
The compilation conditions for wasm [in http-client](https://github.com/http-rs/http-client/blob/main/src/lib.rs#L25) and [in surf](https://github.com/http-rs/surf/blob/cd3ba3ed4d24b168a62132862665c987ed00f37f/src/client.rs#L14) are currently different. This difference causes surf to sometimes (usually when running `cargo check`) try to re-export a module that doesn't exist, leading to the error "could not find `wasm` in `http_client`".

This PR changes to condition in surf to be the same as that in http-client.