### PR TITLE
Upgrade `http-client` to v6.5.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ log = { version = "0.4.7", features = ["kv_unstable"] }
 mime_guess = "2.0.3"
 serde = "1.0.97"
 serde_json = "1.0.40"
-http-client = { version = "6.5.0", default-features = false }
+http-client = { version = "6.5.3", default-features = false }
 http-types = "2.5.0"
 async-std = { version = "1.6.0", default-features = false, features = ["std"] }
 async-trait = "0.1.36"


### PR DESCRIPTION
Version 6.5.0 of `http-client` crate was yanked. Apart from that it contained several vulnerability issues in dependencies like [SNYK-RUST-DASHMAP-2395477](https://security.snyk.io/vuln/SNYK-RUST-DASHMAP-2395477) and [CVE-2023-22466](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-22466)
See issue https://github.com/http-rs/surf/issues/355