### PR TITLE
fix `cargo test` in current version of rustc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ edition = "2018"
 # when the default feature set is updated, verify that the `--features` flags in
 # `.github/workflows/ci.yaml` are updated accordingly
 default = ["curl-client", "middleware-logger", "encoding"]
+docs = []
 curl-client = ["http-client/curl_client", "once_cell", "default-client"]
 h1-client = [
     "http-client/h1_client",


### PR DESCRIPTION
error: unexpected `cfg` condition value: `docs`

note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration